### PR TITLE
Fix docs pr-preview to match standard build

### DIFF
--- a/.github/workflows/test_pages_build.yaml
+++ b/.github/workflows/test_pages_build.yaml
@@ -32,6 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # https://github.com/actions/setup-python
+      - name: Set up Python 3
+        uses: actions/setup-python@v6.0.0
+        with:
+          python-version: 3.13
+
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
         uses: astral-sh/setup-uv@v7.1.2
@@ -40,17 +46,16 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      # https://github.com/actions/setup-python
-      - name: Set up Python 3
-        uses: actions/setup-python@v6.0.0
-        with:
-          python-version: 3.13
+      - name: Install just
+        run: |
+          uv tool install rust-just
 
       - name: Install dependencies
         run: uv sync --dev --no-progress
 
       - name: Build documentation
         run: |
+          just gen-doc
           uv run mkdocs build -d site
           touch site/.nojekyll
 


### PR DESCRIPTION
Issue solved by this PR:
- The docs preview may miss the schema since it does not use the just recipe for building the documentation but only mkdocs directly.

With this PR the docs are build for the preview in the same way as they are build for deployment in `deploy-docs.yaml`.

@StroemPhi - This should fix the problem you reported in the NFDI chat.