### PR TITLE
Add .zenodo.json file to pass author info to Zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,43 @@
+{
+  "access_right": "open",
+  "communities": [
+    {"identifier": "nfdi4cat"},
+    {"identifier": "nfdi4chem"}
+  ],
+  "creators": [
+    {
+      "name": "Str\u00f6mert, Philip",
+      "orcid": "0000-0002-1595-3213",
+      "affiliation": "TIB - Leibniz Information Centre for Science and Technology, Germany"
+    },
+    {
+      "name": "Borgelt, Hendrik",
+      "orcid": "0000-0001-5886-7860",
+      "affiliation": "TU Dortmund University, Germany"
+    },
+    {
+      "name": "Doerr, Mark",
+      "orcid": "0000-0003-3270-6895",
+      "affiliation": "University of Greifswald, Germany"
+    },
+    {
+      "name": "Linke, David",
+      "orcid": "0000-0002-5898-1820",
+      "affiliation": "Leibniz Institute for Catalysis, Albert-Einstein-Str. 29 A, 18059 Rostock, Germany"
+    }
+  ],
+  "description": "<p><a href=\"https://nfdi-de.github.io/dcat-ap-plus/\">DCAT-AP+</a> is a domain-agnostic metadata schema build as extension of the DCAT Application Profile for providing links to use-case specific context. It allows to provide additional metadata regarding: which kind(s) of entity(s) or activity(s) were evaluated (the dcat:Dataset is about), which kind of activity generated the dcat:Dataset, which kind of instruments were used in the dataset generating activity, in which surrounding (e.g. a laboratory) and according to which plan the dataset generating activity took place, as well as regarding which kind(s) of qualitative and quantitative characteristic were attributed to the evaluated entity or evaluated activity and to the used instruments.</p> <p>The metadata schema is developend as <a href=\"https://linkml.io/\">LinkML</a> model which allows to generate various artefacts such as JSON-Schema, SHACL shapes, Python-bindings, and documentation.</p>",
+  "keywords": [
+    "LinkML", "DCAT", "DCAT-AP", "data modelling"
+  ],
+  "license": "MIT",
+  "related_identifiers": [
+    {
+        "identifier": "doi:10.5281/zenodo.5703670",
+        "relation": "requires",
+        "resource_type": "software",
+        "scheme": "doi"
+    }
+  ],
+  "upload_type": "software"
+}


### PR DESCRIPTION
This is required to pass the full author information and one of the steps for solving #22.

Without this file, ORCIDs would not show up in the Zenodo record but only the names from the GitHub user profile,