### PR TITLE
Switched Namespace declaration for DCATAP_Plus in Schema.yml

### DIFF
--- a/src/dcat_ap_plus/datamodel/dcat_ap_plus.py
+++ b/src/dcat_ap_plus/datamodel/dcat_ap_plus.py
@@ -1,5 +1,5 @@
 # Auto generated from dcat_ap_plus.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-11-24T16:42:41
+# Generation date: 2026-01-26T14:14:50
 # Schema: dcat-ap-plus
 #
 # id: https://w3id.org/nfdi-de/dcat-ap-plus/
@@ -60,7 +60,7 @@ from linkml_runtime.linkml_model.types import Date, Decimal, Float, String, Urio
 from linkml_runtime.utils.metamodelcore import Decimal, URIorCURIE, XSDDate
 
 metamodel_version = "1.7.0"
-version = "0.1.0rc1.post21.dev0+3faed58"
+version = "0.1.0rc3.post21.dev0+913fb36"
 
 # Namespaces
 AFE = CurieNamespace('AFE', 'http://purl.allotrope.org/ontologies/equipment#AFE_')
@@ -73,7 +73,7 @@ SOSA = CurieNamespace('SOSA', 'http://www.w3.org/ns/sosa/')
 ADMS = CurieNamespace('adms', 'http://www.w3.org/ns/adms#')
 DCAT = CurieNamespace('dcat', 'http://www.w3.org/ns/dcat#')
 DCATAP = CurieNamespace('dcatap', 'http://data.europa.eu/r5r/')
-DCATAP_PLUS = CurieNamespace('dcatap_plus', 'https://w3id.org/nfdi-de/dcat-ap-plus/')
+DCATAPPLUS = CurieNamespace('dcatapplus', 'https://w3id.org/nfdi-de/dcat-ap-plus/')
 DCTERMS = CurieNamespace('dcterms', 'http://purl.org/dc/terms/')
 ELI = CurieNamespace('eli', 'http://data.europa.eu/eli/ontology#')
 EPOS = CurieNamespace('epos', 'https://www.epos-eu.org/epos-dcat-ap#')
@@ -96,7 +96,7 @@ TIME = CurieNamespace('time', 'http://www.w3.org/2006/time#')
 VCARD = CurieNamespace('vcard', 'http://www.w3.org/2006/vcard/ns#')
 VL = CurieNamespace('vl', 'https://purl.eu/ns/shacl#')
 XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
-DEFAULT_ = DCATAP_PLUS
+DEFAULT_ = DCATAPPLUS
 
 
 # Types
@@ -105,7 +105,7 @@ class Duration(str):
     type_class_uri = XSD["duration"]
     type_class_curie = "xsd:duration"
     type_name = "duration"
-    type_model_uri = DCATAP_PLUS.Duration
+    type_model_uri = DCATAPPLUS.Duration
 
 
 class HexBinary(str):
@@ -113,7 +113,7 @@ class HexBinary(str):
     type_class_uri = XSD["hexBinary"]
     type_class_curie = "xsd:hexBinary"
     type_name = "hexBinary"
-    type_model_uri = DCATAP_PLUS.HexBinary
+    type_model_uri = DCATAPPLUS.HexBinary
 
 
 class NonNegativeInteger(int):
@@ -121,7 +121,7 @@ class NonNegativeInteger(int):
     type_class_uri = XSD["nonNegativeInteger"]
     type_class_curie = "xsd:nonNegativeInteger"
     type_name = "nonNegativeInteger"
-    type_model_uri = DCATAP_PLUS.NonNegativeInteger
+    type_model_uri = DCATAPPLUS.NonNegativeInteger
 
 
 # Class references
@@ -203,7 +203,7 @@ class Activity(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = PROV["Activity"]
     class_class_curie: ClassVar[str] = "prov:Activity"
     class_name: ClassVar[str] = "Activity"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Activity
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Activity
 
     id: Union[str, ActivityId] = None
     title: Optional[Union[str, list[str]]] = empty_list()
@@ -277,7 +277,7 @@ class Agent(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = FOAF["Agent"]
     class_class_curie: ClassVar[str] = "foaf:Agent"
     class_name: ClassVar[str] = "Agent"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Agent
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Agent
 
     name: Union[str, list[str]] = None
     type: Optional[Union[dict, "Concept"]] = None
@@ -305,7 +305,7 @@ class AgenticEntity(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = PROV["Agent"]
     class_class_curie: ClassVar[str] = "prov:Agent"
     class_name: ClassVar[str] = "AgenticEntity"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.AgenticEntity
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.AgenticEntity
 
     id: Union[str, AgenticEntityId] = None
     title: Optional[str] = None
@@ -367,7 +367,7 @@ class Catalogue(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = DCAT["Catalog"]
     class_class_curie: ClassVar[str] = "dcat:Catalog"
     class_name: ClassVar[str] = "Catalogue"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Catalogue
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Catalogue
 
     description: Union[str, list[str]] = None
     publisher: Union[dict, Agent] = None
@@ -474,7 +474,7 @@ class CatalogueRecord(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = DCAT["CatalogRecord"]
     class_class_curie: ClassVar[str] = "dcat:CatalogRecord"
     class_name: ClassVar[str] = "CatalogueRecord"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.CatalogueRecord
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.CatalogueRecord
 
     modification_date: Union[str, XSDDate] = None
     primary_topic: Union[dict, Any] = None
@@ -530,7 +530,7 @@ class Checksum(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = SPDX["Checksum"]
     class_class_curie: ClassVar[str] = "spdx:Checksum"
     class_name: ClassVar[str] = "Checksum"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Checksum
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Checksum
 
     algorithm: Union[dict, "ChecksumAlgorithm"] = None
     checksum_value: str = None
@@ -556,10 +556,10 @@ class ClassifierMixin(YAMLRoot):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = DCATAP_PLUS["ClassifierMixin"]
-    class_class_curie: ClassVar[str] = "dcatap_plus:ClassifierMixin"
+    class_class_uri: ClassVar[URIRef] = DCATAPPLUS["ClassifierMixin"]
+    class_class_curie: ClassVar[str] = "dcatapplus:ClassifierMixin"
     class_name: ClassVar[str] = "ClassifierMixin"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.ClassifierMixin
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.ClassifierMixin
 
     type: Optional[Union[dict, "DefinedTerm"]] = None
     rdf_type: Optional[Union[dict, "DefinedTerm"]] = None
@@ -585,7 +585,7 @@ class DataGeneratingActivity(Activity):
     class_class_uri: ClassVar[URIRef] = PROV["Activity"]
     class_class_curie: ClassVar[str] = "prov:Activity"
     class_name: ClassVar[str] = "DataGeneratingActivity"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.DataGeneratingActivity
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.DataGeneratingActivity
 
     id: Union[str, DataGeneratingActivityId] = None
     evaluated_entity: Optional[Union[dict[Union[str, EvaluatedEntityId], Union[dict, "EvaluatedEntity"]], list[Union[dict, "EvaluatedEntity"]]]] = empty_dict()
@@ -622,7 +622,7 @@ class DataAnalysis(DataGeneratingActivity):
     class_class_uri: ClassVar[URIRef] = PROV["Activity"]
     class_class_curie: ClassVar[str] = "prov:Activity"
     class_name: ClassVar[str] = "DataAnalysis"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.DataAnalysis
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.DataAnalysis
 
     id: Union[str, DataAnalysisId] = None
     evaluated_entity: Optional[Union[dict[Union[str, AnalysisSourceDataId], Union[dict, "AnalysisSourceData"]], list[Union[dict, "AnalysisSourceData"]]]] = empty_dict()
@@ -648,7 +648,7 @@ class DataService(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = DCAT["DataService"]
     class_class_curie: ClassVar[str] = "dcat:DataService"
     class_name: ClassVar[str] = "DataService"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.DataService
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.DataService
 
     endpoint_URL: Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]] = empty_dict()
     title: Union[str, list[str]] = None
@@ -735,7 +735,7 @@ class Dataset(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = DCAT["Dataset"]
     class_class_curie: ClassVar[str] = "dcat:Dataset"
     class_name: ClassVar[str] = "Dataset"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Dataset
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Dataset
 
     id: Union[str, DatasetId] = None
     description: Union[str, list[str]] = None
@@ -928,7 +928,7 @@ class AnalysisDataset(Dataset):
     class_class_uri: ClassVar[URIRef] = DCAT["Dataset"]
     class_class_curie: ClassVar[str] = "dcat:Dataset"
     class_name: ClassVar[str] = "AnalysisDataset"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.AnalysisDataset
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.AnalysisDataset
 
     id: Union[str, AnalysisDatasetId] = None
     description: Union[str, list[str]] = None
@@ -956,7 +956,7 @@ class DatasetSeries(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = DCAT["DatasetSeries"]
     class_class_curie: ClassVar[str] = "dcat:DatasetSeries"
     class_name: ClassVar[str] = "DatasetSeries"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.DatasetSeries
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.DatasetSeries
 
     description: Union[str, list[str]] = None
     title: Union[str, list[str]] = None
@@ -1022,7 +1022,7 @@ class DefinedTerm(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = SCHEMA["DefinedTerm"]
     class_class_curie: ClassVar[str] = "schema:DefinedTerm"
     class_name: ClassVar[str] = "DefinedTerm"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.DefinedTerm
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.DefinedTerm
 
     id: Union[str, DefinedTermId] = None
     title: Optional[str] = None
@@ -1054,7 +1054,7 @@ class Device(AgenticEntity):
     class_class_uri: ClassVar[URIRef] = PROV["Agent"]
     class_class_curie: ClassVar[str] = "prov:Agent"
     class_name: ClassVar[str] = "Device"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Device
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Device
 
     id: Union[str, DeviceId] = None
     has_part: Optional[Union[dict[Union[str, DeviceId], Union[dict, "Device"]], list[Union[dict, "Device"]]]] = empty_dict()
@@ -1085,7 +1085,7 @@ class Distribution(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = DCAT["Distribution"]
     class_class_curie: ClassVar[str] = "dcat:Distribution"
     class_name: ClassVar[str] = "Distribution"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Distribution
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Distribution
 
     access_URL: Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]] = empty_dict()
     access_service: Optional[Union[Union[dict, DataService], list[Union[dict, DataService]]]] = empty_list()
@@ -1201,7 +1201,7 @@ class Entity(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = PROV["Entity"]
     class_class_curie: ClassVar[str] = "prov:Entity"
     class_name: ClassVar[str] = "Entity"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Entity
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Entity
 
     id: Union[str, EntityId] = None
     title: Optional[str] = None
@@ -1261,7 +1261,7 @@ class EvaluatedActivity(Activity):
     class_class_uri: ClassVar[URIRef] = PROV["Activity"]
     class_class_curie: ClassVar[str] = "prov:Activity"
     class_name: ClassVar[str] = "EvaluatedActivity"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.EvaluatedActivity
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.EvaluatedActivity
 
     id: Union[str, EvaluatedActivityId] = None
     other_identifier: Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]] = empty_list()
@@ -1289,7 +1289,7 @@ class EvaluatedEntity(Entity):
     class_class_uri: ClassVar[URIRef] = PROV["Entity"]
     class_class_curie: ClassVar[str] = "prov:Entity"
     class_name: ClassVar[str] = "EvaluatedEntity"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.EvaluatedEntity
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.EvaluatedEntity
 
     id: Union[str, EvaluatedEntityId] = None
     was_generated_by: Optional[Union[dict[Union[str, ActivityId], Union[dict, Activity]], list[Union[dict, Activity]]]] = empty_dict()
@@ -1328,7 +1328,7 @@ class AnalysisSourceData(EvaluatedEntity):
     class_class_uri: ClassVar[URIRef] = PROV["Entity"]
     class_class_curie: ClassVar[str] = "prov:Entity"
     class_name: ClassVar[str] = "AnalysisSourceData"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.AnalysisSourceData
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.AnalysisSourceData
 
     id: Union[str, AnalysisSourceDataId] = None
     was_generated_by: Optional[Union[dict[Union[str, DataGeneratingActivityId], Union[dict, DataGeneratingActivity]], list[Union[dict, DataGeneratingActivity]]]] = empty_dict()
@@ -1353,7 +1353,7 @@ class Kind(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = VCARD["Kind"]
     class_class_curie: ClassVar[str] = "vcard:Kind"
     class_name: ClassVar[str] = "Kind"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Kind
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Kind
 
 
 @dataclass(repr=False)
@@ -1366,7 +1366,7 @@ class Location(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = DCTERMS["Location"]
     class_class_curie: ClassVar[str] = "dcterms:Location"
     class_name: ClassVar[str] = "Location"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Location
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Location
 
     bbox: Optional[str] = None
     centroid: Optional[str] = None
@@ -1396,7 +1396,7 @@ class Plan(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = PROV["Plan"]
     class_class_curie: ClassVar[str] = "prov:Plan"
     class_name: ClassVar[str] = "Plan"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Plan
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Plan
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1429,7 +1429,7 @@ class QualitativeAttribute(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = PROV["Entity"]
     class_class_curie: ClassVar[str] = "prov:Entity"
     class_name: ClassVar[str] = "QualitativeAttribute"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.QualitativeAttribute
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.QualitativeAttribute
 
     value: str = None
     title: Optional[str] = None
@@ -1468,7 +1468,7 @@ class QuantitativeAttribute(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = QUDT["Quantity"]
     class_class_curie: ClassVar[str] = "qudt:Quantity"
     class_name: ClassVar[str] = "QuantitativeAttribute"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.QuantitativeAttribute
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.QuantitativeAttribute
 
     value: float = None
     has_quantity_type: Union[str, DefinedTermId] = None
@@ -1517,7 +1517,7 @@ class Relationship(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = DCAT["Relationship"]
     class_class_curie: ClassVar[str] = "dcat:Relationship"
     class_name: ClassVar[str] = "Relationship"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Relationship
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Relationship
 
     had_role: Union[Union[dict, "Role"], list[Union[dict, "Role"]]] = None
     relation: Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]] = empty_dict()
@@ -1546,7 +1546,7 @@ class Software(AgenticEntity):
     class_class_uri: ClassVar[URIRef] = PROV["SoftwareAgent"]
     class_class_curie: ClassVar[str] = "prov:SoftwareAgent"
     class_name: ClassVar[str] = "Software"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Software
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Software
 
     id: Union[str, SoftwareId] = None
     has_part: Optional[Union[dict[Union[str, SoftwareId], Union[dict, "Software"]], list[Union[dict, "Software"]]]] = empty_dict()
@@ -1575,10 +1575,10 @@ class SupportiveEntity(YAMLRoot):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = DCATAP_PLUS["SupportiveEntity"]
-    class_class_curie: ClassVar[str] = "dcatap_plus:SupportiveEntity"
+    class_class_uri: ClassVar[URIRef] = DCATAPPLUS["SupportiveEntity"]
+    class_class_curie: ClassVar[str] = "dcatapplus:SupportiveEntity"
     class_name: ClassVar[str] = "SupportiveEntity"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.SupportiveEntity
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.SupportiveEntity
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1603,7 +1603,7 @@ class Attribution(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = PROV["Attribution"]
     class_class_curie: ClassVar[str] = "prov:Attribution"
     class_name: ClassVar[str] = "Attribution"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Attribution
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Attribution
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1628,7 +1628,7 @@ class ChecksumAlgorithm(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = SPDX["ChecksumAlgorithm"]
     class_class_curie: ClassVar[str] = "spdx:ChecksumAlgorithm"
     class_name: ClassVar[str] = "ChecksumAlgorithm"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.ChecksumAlgorithm
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.ChecksumAlgorithm
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1653,7 +1653,7 @@ class Concept(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = SKOS["Concept"]
     class_class_curie: ClassVar[str] = "skos:Concept"
     class_name: ClassVar[str] = "Concept"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Concept
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Concept
 
     preferred_label: Union[str, list[str]] = None
     title: Optional[str] = None
@@ -1685,7 +1685,7 @@ class ConceptScheme(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = SKOS["ConceptScheme"]
     class_class_curie: ClassVar[str] = "skos:ConceptScheme"
     class_name: ClassVar[str] = "ConceptScheme"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.ConceptScheme
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.ConceptScheme
 
     title: Union[str, list[str]] = None
     description: Optional[str] = None
@@ -1713,7 +1713,7 @@ class Document(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = FOAF["Document"]
     class_class_curie: ClassVar[str] = "foaf:Document"
     class_name: ClassVar[str] = "Document"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Document
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Document
 
     id: Union[str, DocumentId] = None
     title: Optional[str] = None
@@ -1744,7 +1744,7 @@ class Frequency(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["Frequency"]
     class_class_curie: ClassVar[str] = "dcterms:Frequency"
     class_name: ClassVar[str] = "Frequency"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Frequency
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Frequency
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1769,7 +1769,7 @@ class Geometry(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = LOCN["Geometry"]
     class_class_curie: ClassVar[str] = "locn:Geometry"
     class_name: ClassVar[str] = "Geometry"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Geometry
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Geometry
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1794,7 +1794,7 @@ class Identifier(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = ADMS["Identifier"]
     class_class_curie: ClassVar[str] = "adms:Identifier"
     class_name: ClassVar[str] = "Identifier"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Identifier
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Identifier
 
     notation: str = None
     title: Optional[str] = None
@@ -1825,7 +1825,7 @@ class LegalResource(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = ELI["LegalResource"]
     class_class_curie: ClassVar[str] = "eli:LegalResource"
     class_name: ClassVar[str] = "LegalResource"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.LegalResource
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.LegalResource
 
     id: Union[str, LegalResourceId] = None
     title: Optional[str] = None
@@ -1856,7 +1856,7 @@ class LicenseDocument(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["LicenseDocument"]
     class_class_curie: ClassVar[str] = "dcterms:LicenseDocument"
     class_name: ClassVar[str] = "LicenseDocument"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.LicenseDocument
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.LicenseDocument
 
     id: Union[str, LicenseDocumentId] = None
     type: Optional[Union[Union[dict, Concept], list[Union[dict, Concept]]]] = empty_list()
@@ -1892,7 +1892,7 @@ class LinguisticSystem(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["LinguisticSystem"]
     class_class_curie: ClassVar[str] = "dcterms:LinguisticSystem"
     class_name: ClassVar[str] = "LinguisticSystem"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.LinguisticSystem
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.LinguisticSystem
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1917,7 +1917,7 @@ class MediaType(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["MediaType"]
     class_class_curie: ClassVar[str] = "dcterms:MediaType"
     class_name: ClassVar[str] = "MediaType"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.MediaType
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.MediaType
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1942,7 +1942,7 @@ class MediaTypeOrExtent(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["MediaTypeOrExtent"]
     class_class_curie: ClassVar[str] = "dcterms:MediaTypeOrExtent"
     class_name: ClassVar[str] = "MediaTypeOrExtent"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.MediaTypeOrExtent
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.MediaTypeOrExtent
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -1967,7 +1967,7 @@ class PeriodOfTime(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["PeriodOfTime"]
     class_class_curie: ClassVar[str] = "dcterms:PeriodOfTime"
     class_name: ClassVar[str] = "PeriodOfTime"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.PeriodOfTime
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.PeriodOfTime
 
     beginning: Optional[Union[dict, "TimeInstant"]] = None
     end: Optional[Union[dict, "TimeInstant"]] = None
@@ -2008,7 +2008,7 @@ class Policy(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = ODRL["Policy"]
     class_class_curie: ClassVar[str] = "odrl:Policy"
     class_name: ClassVar[str] = "Policy"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Policy
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Policy
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -2033,7 +2033,7 @@ class ProvenanceStatement(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["ProvenanceStatement"]
     class_class_curie: ClassVar[str] = "dcterms:ProvenanceStatement"
     class_name: ClassVar[str] = "ProvenanceStatement"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.ProvenanceStatement
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.ProvenanceStatement
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -2058,7 +2058,7 @@ class Resource(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = RDFS["Resource"]
     class_class_curie: ClassVar[str] = "rdfs:Resource"
     class_name: ClassVar[str] = "Resource"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Resource
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Resource
 
     id: Union[str, ResourceId] = None
     title: Optional[str] = None
@@ -2089,7 +2089,7 @@ class RightsStatement(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["RightsStatement"]
     class_class_curie: ClassVar[str] = "dcterms:RightsStatement"
     class_name: ClassVar[str] = "RightsStatement"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.RightsStatement
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.RightsStatement
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -2114,7 +2114,7 @@ class Role(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCAT["Role"]
     class_class_curie: ClassVar[str] = "dcat:Role"
     class_name: ClassVar[str] = "Role"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Role
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Role
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -2139,7 +2139,7 @@ class Standard(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = DCTERMS["Standard"]
     class_class_curie: ClassVar[str] = "dcterms:Standard"
     class_name: ClassVar[str] = "Standard"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Standard
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Standard
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -2164,7 +2164,7 @@ class Surrounding(YAMLRoot):
     class_class_uri: ClassVar[URIRef] = PROV["Location"]
     class_class_curie: ClassVar[str] = "prov:Location"
     class_name: ClassVar[str] = "Surrounding"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.Surrounding
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.Surrounding
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -2197,7 +2197,7 @@ class TimeInstant(SupportiveEntity):
     class_class_uri: ClassVar[URIRef] = TIME["Instant"]
     class_class_curie: ClassVar[str] = "time:Instant"
     class_name: ClassVar[str] = "TimeInstant"
-    class_model_uri: ClassVar[URIRef] = DCATAP_PLUS.TimeInstant
+    class_model_uri: ClassVar[URIRef] = DCATAPPLUS.TimeInstant
 
     title: Optional[str] = None
     description: Optional[str] = None
@@ -2317,796 +2317,796 @@ class slots:
     pass
 
 slots.access_URL = Slot(uri=DCAT.accessURL, name="access_URL", curie=DCAT.curie('accessURL'),
-                   model_uri=DCATAP_PLUS.access_URL, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.access_URL, domain=None, range=Optional[str])
 
 slots.access_rights = Slot(uri=DCTERMS.accessRights, name="access_rights", curie=DCTERMS.curie('accessRights'),
-                   model_uri=DCATAP_PLUS.access_rights, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.access_rights, domain=None, range=Optional[str])
 
 slots.access_service = Slot(uri=DCAT.accessService, name="access_service", curie=DCAT.curie('accessService'),
-                   model_uri=DCATAP_PLUS.access_service, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.access_service, domain=None, range=Optional[str])
 
 slots.algorithm = Slot(uri=SPDX.algorithm, name="algorithm", curie=SPDX.curie('algorithm'),
-                   model_uri=DCATAP_PLUS.algorithm, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.algorithm, domain=None, range=Optional[str])
 
 slots.applicable_legislation = Slot(uri=DCATAP.applicableLegislation, name="applicable_legislation", curie=DCATAP.curie('applicableLegislation'),
-                   model_uri=DCATAP_PLUS.applicable_legislation, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.applicable_legislation, domain=None, range=Optional[str])
 
 slots.application_profile = Slot(uri=DCTERMS.conformsTo, name="application_profile", curie=DCTERMS.curie('conformsTo'),
-                   model_uri=DCATAP_PLUS.application_profile, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.application_profile, domain=None, range=Optional[str])
 
 slots.availability = Slot(uri=DCATAP.availability, name="availability", curie=DCATAP.curie('availability'),
-                   model_uri=DCATAP_PLUS.availability, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.availability, domain=None, range=Optional[str])
 
 slots.bbox = Slot(uri=DCAT.bbox, name="bbox", curie=DCAT.curie('bbox'),
-                   model_uri=DCATAP_PLUS.bbox, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.bbox, domain=None, range=Optional[str])
 
 slots.beginning = Slot(uri=TIME.hasBeginning, name="beginning", curie=TIME.curie('hasBeginning'),
-                   model_uri=DCATAP_PLUS.beginning, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.beginning, domain=None, range=Optional[str])
 
 slots.byte_size = Slot(uri=DCAT.byteSize, name="byte_size", curie=DCAT.curie('byteSize'),
-                   model_uri=DCATAP_PLUS.byte_size, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.byte_size, domain=None, range=Optional[str])
 
 slots.carried_out_by = Slot(uri=PROV.wasAssociatedWith, name="carried_out_by", curie=PROV.curie('wasAssociatedWith'),
-                   model_uri=DCATAP_PLUS.carried_out_by, domain=None, range=Optional[Union[dict[Union[str, AgenticEntityId], Union[dict, AgenticEntity]], list[Union[dict, AgenticEntity]]]])
+                   model_uri=DCATAPPLUS.carried_out_by, domain=None, range=Optional[Union[dict[Union[str, AgenticEntityId], Union[dict, AgenticEntity]], list[Union[dict, AgenticEntity]]]])
 
 slots.catalogue = Slot(uri=DCAT.catalog, name="catalogue", curie=DCAT.curie('catalog'),
-                   model_uri=DCATAP_PLUS.catalogue, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.catalogue, domain=None, range=Optional[str])
 
 slots.centroid = Slot(uri=DCAT.centroid, name="centroid", curie=DCAT.curie('centroid'),
-                   model_uri=DCATAP_PLUS.centroid, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.centroid, domain=None, range=Optional[str])
 
 slots.change_type = Slot(uri=ADMS.status, name="change_type", curie=ADMS.curie('status'),
-                   model_uri=DCATAP_PLUS.change_type, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.change_type, domain=None, range=Optional[str])
 
 slots.checksum = Slot(uri=SPDX.checksum, name="checksum", curie=SPDX.curie('checksum'),
-                   model_uri=DCATAP_PLUS.checksum, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.checksum, domain=None, range=Optional[str])
 
 slots.checksum_value = Slot(uri=SPDX.checksumValue, name="checksum_value", curie=SPDX.curie('checksumValue'),
-                   model_uri=DCATAP_PLUS.checksum_value, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.checksum_value, domain=None, range=Optional[str])
 
 slots.compression_format = Slot(uri=DCAT.compressFormat, name="compression_format", curie=DCAT.curie('compressFormat'),
-                   model_uri=DCATAP_PLUS.compression_format, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.compression_format, domain=None, range=Optional[str])
 
 slots.conforms_to = Slot(uri=DCTERMS.conformsTo, name="conforms_to", curie=DCTERMS.curie('conformsTo'),
-                   model_uri=DCATAP_PLUS.conforms_to, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.conforms_to, domain=None, range=Optional[str])
 
 slots.contact_point = Slot(uri=DCAT.contactPoint, name="contact_point", curie=DCAT.curie('contactPoint'),
-                   model_uri=DCATAP_PLUS.contact_point, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.contact_point, domain=None, range=Optional[str])
 
 slots.creator = Slot(uri=DCTERMS.creator, name="creator", curie=DCTERMS.curie('creator'),
-                   model_uri=DCATAP_PLUS.creator, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.creator, domain=None, range=Optional[str])
 
 slots.dataset_distribution = Slot(uri=DCAT.distribution, name="dataset_distribution", curie=DCAT.curie('distribution'),
-                   model_uri=DCATAP_PLUS.dataset_distribution, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.dataset_distribution, domain=None, range=Optional[str])
 
 slots.description = Slot(uri=DCTERMS.description, name="description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.description, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.description, domain=None, range=Optional[str])
 
 slots.documentation = Slot(uri=FOAF.page, name="documentation", curie=FOAF.curie('page'),
-                   model_uri=DCATAP_PLUS.documentation, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.documentation, domain=None, range=Optional[str])
 
 slots.download_URL = Slot(uri=DCAT.downloadURL, name="download_URL", curie=DCAT.curie('downloadURL'),
-                   model_uri=DCATAP_PLUS.download_URL, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.download_URL, domain=None, range=Optional[str])
 
 slots.end = Slot(uri=TIME.hasEnd, name="end", curie=TIME.curie('hasEnd'),
-                   model_uri=DCATAP_PLUS.end, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.end, domain=None, range=Optional[str])
 
 slots.end_date = Slot(uri=DCAT.endDate, name="end_date", curie=DCAT.curie('endDate'),
-                   model_uri=DCATAP_PLUS.end_date, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.end_date, domain=None, range=Optional[str])
 
 slots.endpoint_URL = Slot(uri=DCAT.endpointURL, name="endpoint_URL", curie=DCAT.curie('endpointURL'),
-                   model_uri=DCATAP_PLUS.endpoint_URL, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.endpoint_URL, domain=None, range=Optional[str])
 
 slots.endpoint_description = Slot(uri=DCAT.endpointDescription, name="endpoint_description", curie=DCAT.curie('endpointDescription'),
-                   model_uri=DCATAP_PLUS.endpoint_description, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.endpoint_description, domain=None, range=Optional[str])
 
 slots.evaluated_activity = Slot(uri=PROV.wasInformedBy, name="evaluated_activity", curie=PROV.curie('wasInformedBy'),
-                   model_uri=DCATAP_PLUS.evaluated_activity, domain=None, range=Optional[Union[dict[Union[str, EvaluatedActivityId], Union[dict, EvaluatedActivity]], list[Union[dict, EvaluatedActivity]]]])
+                   model_uri=DCATAPPLUS.evaluated_activity, domain=None, range=Optional[Union[dict[Union[str, EvaluatedActivityId], Union[dict, EvaluatedActivity]], list[Union[dict, EvaluatedActivity]]]])
 
 slots.evaluated_entity = Slot(uri=PROV.used, name="evaluated_entity", curie=PROV.curie('used'),
-                   model_uri=DCATAP_PLUS.evaluated_entity, domain=None, range=Optional[Union[dict[Union[str, EvaluatedEntityId], Union[dict, EvaluatedEntity]], list[Union[dict, EvaluatedEntity]]]])
+                   model_uri=DCATAPPLUS.evaluated_entity, domain=None, range=Optional[Union[dict[Union[str, EvaluatedEntityId], Union[dict, EvaluatedEntity]], list[Union[dict, EvaluatedEntity]]]])
 
 slots.format = Slot(uri=DCTERMS.format, name="format", curie=DCTERMS.curie('format'),
-                   model_uri=DCATAP_PLUS.format, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.format, domain=None, range=Optional[str])
 
 slots.frequency = Slot(uri=DCTERMS.accrualPeriodicity, name="frequency", curie=DCTERMS.curie('accrualPeriodicity'),
-                   model_uri=DCATAP_PLUS.frequency, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.frequency, domain=None, range=Optional[str])
 
 slots.geographical_coverage = Slot(uri=DCTERMS.spatial, name="geographical_coverage", curie=DCTERMS.curie('spatial'),
-                   model_uri=DCATAP_PLUS.geographical_coverage, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.geographical_coverage, domain=None, range=Optional[str])
 
 slots.geometry = Slot(uri=LOCN.geometry, name="geometry", curie=LOCN.curie('geometry'),
-                   model_uri=DCATAP_PLUS.geometry, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.geometry, domain=None, range=Optional[str])
 
 slots.had_input_activity = Slot(uri=PROV.wasInformedBy, name="had_input_activity", curie=PROV.curie('wasInformedBy'),
-                   model_uri=DCATAP_PLUS.had_input_activity, domain=None, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, Activity]], list[Union[dict, Activity]]]])
+                   model_uri=DCATAPPLUS.had_input_activity, domain=None, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, Activity]], list[Union[dict, Activity]]]])
 
 slots.had_input_entity = Slot(uri=PROV.used, name="had_input_entity", curie=PROV.curie('used'),
-                   model_uri=DCATAP_PLUS.had_input_entity, domain=None, range=Optional[Union[dict[Union[str, EntityId], Union[dict, Entity]], list[Union[dict, Entity]]]])
+                   model_uri=DCATAPPLUS.had_input_entity, domain=None, range=Optional[Union[dict[Union[str, EntityId], Union[dict, Entity]], list[Union[dict, Entity]]]])
 
 slots.had_output_entity = Slot(uri=PROV.generated, name="had_output_entity", curie=PROV.curie('generated'),
-                   model_uri=DCATAP_PLUS.had_output_entity, domain=None, range=Optional[Union[dict[Union[str, EntityId], Union[dict, Entity]], list[Union[dict, Entity]]]])
+                   model_uri=DCATAPPLUS.had_output_entity, domain=None, range=Optional[Union[dict[Union[str, EntityId], Union[dict, Entity]], list[Union[dict, Entity]]]])
 
 slots.had_role = Slot(uri=DCAT.hadRole, name="had_role", curie=DCAT.curie('hadRole'),
-                   model_uri=DCATAP_PLUS.had_role, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.had_role, domain=None, range=Optional[str])
 
 slots.has_dataset = Slot(uri=DCAT.dataset, name="has_dataset", curie=DCAT.curie('dataset'),
-                   model_uri=DCATAP_PLUS.has_dataset, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.has_dataset, domain=None, range=Optional[str])
 
 slots.has_part = Slot(uri=DCTERMS.hasPart, name="has_part", curie=DCTERMS.curie('hasPart'),
-                   model_uri=DCATAP_PLUS.has_part, domain=None, range=Optional[Union[str, ActivityId]])
+                   model_uri=DCATAPPLUS.has_part, domain=None, range=Optional[Union[str, ActivityId]])
 
 slots.has_policy = Slot(uri=ODRL.hasPolicy, name="has_policy", curie=ODRL.curie('hasPolicy'),
-                   model_uri=DCATAP_PLUS.has_policy, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.has_policy, domain=None, range=Optional[str])
 
 slots.has_qualitative_attribute = Slot(uri=DCTERMS.relation, name="has_qualitative_attribute", curie=DCTERMS.curie('relation'),
-                   model_uri=DCATAP_PLUS.has_qualitative_attribute, domain=None, range=Optional[Union[Union[dict, QualitativeAttribute], list[Union[dict, QualitativeAttribute]]]])
+                   model_uri=DCATAPPLUS.has_qualitative_attribute, domain=None, range=Optional[Union[Union[dict, QualitativeAttribute], list[Union[dict, QualitativeAttribute]]]])
 
 slots.has_quantitative_attribute = Slot(uri=DCTERMS.relation, name="has_quantitative_attribute", curie=DCTERMS.curie('relation'),
-                   model_uri=DCATAP_PLUS.has_quantitative_attribute, domain=None, range=Optional[Union[Union[dict, QuantitativeAttribute], list[Union[dict, QuantitativeAttribute]]]])
+                   model_uri=DCATAPPLUS.has_quantitative_attribute, domain=None, range=Optional[Union[Union[dict, QuantitativeAttribute], list[Union[dict, QuantitativeAttribute]]]])
 
 slots.has_version = Slot(uri=DCAT.hasVersion, name="has_version", curie=DCAT.curie('hasVersion'),
-                   model_uri=DCATAP_PLUS.has_version, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.has_version, domain=None, range=Optional[str])
 
 slots.homepage = Slot(uri=FOAF.homepage, name="homepage", curie=FOAF.curie('homepage'),
-                   model_uri=DCATAP_PLUS.homepage, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.homepage, domain=None, range=Optional[str])
 
-slots.id = Slot(uri=DCATAP_PLUS.id, name="id", curie=DCATAP_PLUS.curie('id'),
-                   model_uri=DCATAP_PLUS.id, domain=None, range=URIRef)
+slots.id = Slot(uri=DCATAPPLUS.id, name="id", curie=DCATAPPLUS.curie('id'),
+                   model_uri=DCATAPPLUS.id, domain=None, range=URIRef)
 
 slots.identifier = Slot(uri=DCTERMS.identifier, name="identifier", curie=DCTERMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.identifier, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.identifier, domain=None, range=Optional[str])
 
 slots.in_series = Slot(uri=DCAT.inSeries, name="in_series", curie=DCAT.curie('inSeries'),
-                   model_uri=DCATAP_PLUS.in_series, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.in_series, domain=None, range=Optional[str])
 
 slots.is_about_activity = Slot(uri=DCTERMS.subject, name="is_about_activity", curie=DCTERMS.curie('subject'),
-                   model_uri=DCATAP_PLUS.is_about_activity, domain=None, range=Optional[Union[dict[Union[str, EvaluatedActivityId], Union[dict, EvaluatedActivity]], list[Union[dict, EvaluatedActivity]]]])
+                   model_uri=DCATAPPLUS.is_about_activity, domain=None, range=Optional[Union[dict[Union[str, EvaluatedActivityId], Union[dict, EvaluatedActivity]], list[Union[dict, EvaluatedActivity]]]])
 
 slots.is_about_entity = Slot(uri=DCTERMS.subject, name="is_about_entity", curie=DCTERMS.curie('subject'),
-                   model_uri=DCATAP_PLUS.is_about_entity, domain=None, range=Optional[Union[dict[Union[str, EvaluatedEntityId], Union[dict, EvaluatedEntity]], list[Union[dict, EvaluatedEntity]]]])
+                   model_uri=DCATAPPLUS.is_about_entity, domain=None, range=Optional[Union[dict[Union[str, EvaluatedEntityId], Union[dict, EvaluatedEntity]], list[Union[dict, EvaluatedEntity]]]])
 
 slots.is_referenced_by = Slot(uri=DCTERMS.isReferencedBy, name="is_referenced_by", curie=DCTERMS.curie('isReferencedBy'),
-                   model_uri=DCATAP_PLUS.is_referenced_by, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.is_referenced_by, domain=None, range=Optional[str])
 
 slots.keyword = Slot(uri=DCAT.keyword, name="keyword", curie=DCAT.curie('keyword'),
-                   model_uri=DCATAP_PLUS.keyword, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.keyword, domain=None, range=Optional[str])
 
 slots.landing_page = Slot(uri=DCAT.landingPage, name="landing_page", curie=DCAT.curie('landingPage'),
-                   model_uri=DCATAP_PLUS.landing_page, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.landing_page, domain=None, range=Optional[str])
 
 slots.language = Slot(uri=DCTERMS.language, name="language", curie=DCTERMS.curie('language'),
-                   model_uri=DCATAP_PLUS.language, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.language, domain=None, range=Optional[str])
 
 slots.licence = Slot(uri=DCTERMS.license, name="licence", curie=DCTERMS.curie('license'),
-                   model_uri=DCATAP_PLUS.licence, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.licence, domain=None, range=Optional[str])
 
 slots.linked_schemas = Slot(uri=DCTERMS.conformsTo, name="linked_schemas", curie=DCTERMS.curie('conformsTo'),
-                   model_uri=DCATAP_PLUS.linked_schemas, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.linked_schemas, domain=None, range=Optional[str])
 
 slots.listing_date = Slot(uri=DCTERMS.issued, name="listing_date", curie=DCTERMS.curie('issued'),
-                   model_uri=DCATAP_PLUS.listing_date, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.listing_date, domain=None, range=Optional[str])
 
 slots.media_type = Slot(uri=DCAT.mediaType, name="media_type", curie=DCAT.curie('mediaType'),
-                   model_uri=DCATAP_PLUS.media_type, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.media_type, domain=None, range=Optional[str])
 
 slots.modification_date = Slot(uri=DCTERMS.modified, name="modification_date", curie=DCTERMS.curie('modified'),
-                   model_uri=DCATAP_PLUS.modification_date, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.modification_date, domain=None, range=Optional[str])
 
 slots.name = Slot(uri=FOAF.name, name="name", curie=FOAF.curie('name'),
-                   model_uri=DCATAP_PLUS.name, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.name, domain=None, range=Optional[str])
 
 slots.notation = Slot(uri=SKOS.notation, name="notation", curie=SKOS.curie('notation'),
-                   model_uri=DCATAP_PLUS.notation, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.notation, domain=None, range=Optional[str])
 
 slots.occurred_in = Slot(uri=PROV.atLocation, name="occurred_in", curie=PROV.curie('atLocation'),
-                   model_uri=DCATAP_PLUS.occurred_in, domain=None, range=Optional[Union[dict, Surrounding]])
+                   model_uri=DCATAPPLUS.occurred_in, domain=None, range=Optional[Union[dict, Surrounding]])
 
 slots.other_identifier = Slot(uri=ADMS.identifier, name="other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.other_identifier, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.other_identifier, domain=None, range=Optional[str])
 
 slots.packaging_format = Slot(uri=DCAT.packageFormat, name="packaging_format", curie=DCAT.curie('packageFormat'),
-                   model_uri=DCATAP_PLUS.packaging_format, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.packaging_format, domain=None, range=Optional[str])
 
 slots.part_of = Slot(uri=DCTERMS.isPartOf, name="part_of", curie=DCTERMS.curie('isPartOf'),
-                   model_uri=DCATAP_PLUS.part_of, domain=None, range=Optional[Union[str, ActivityId]])
+                   model_uri=DCATAPPLUS.part_of, domain=None, range=Optional[Union[str, ActivityId]])
 
 slots.preferred_label = Slot(uri=SKOS.prefLabel, name="preferred_label", curie=SKOS.curie('prefLabel'),
-                   model_uri=DCATAP_PLUS.preferred_label, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.preferred_label, domain=None, range=Optional[str])
 
 slots.primary_topic = Slot(uri=FOAF.primaryTopic, name="primary_topic", curie=FOAF.curie('primaryTopic'),
-                   model_uri=DCATAP_PLUS.primary_topic, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.primary_topic, domain=None, range=Optional[str])
 
 slots.provenance = Slot(uri=DCTERMS.provenance, name="provenance", curie=DCTERMS.curie('provenance'),
-                   model_uri=DCATAP_PLUS.provenance, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.provenance, domain=None, range=Optional[str])
 
 slots.publisher = Slot(uri=DCTERMS.publisher, name="publisher", curie=DCTERMS.curie('publisher'),
-                   model_uri=DCATAP_PLUS.publisher, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.publisher, domain=None, range=Optional[str])
 
 slots.qualified_attribution = Slot(uri=PROV.qualifiedAttribution, name="qualified_attribution", curie=PROV.curie('qualifiedAttribution'),
-                   model_uri=DCATAP_PLUS.qualified_attribution, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.qualified_attribution, domain=None, range=Optional[str])
 
 slots.qualified_relation = Slot(uri=DCAT.qualifiedRelation, name="qualified_relation", curie=DCAT.curie('qualifiedRelation'),
-                   model_uri=DCATAP_PLUS.qualified_relation, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.qualified_relation, domain=None, range=Optional[str])
 
 slots.rdf_type = Slot(uri=RDF.type, name="rdf_type", curie=RDF.curie('type'),
-                   model_uri=DCATAP_PLUS.rdf_type, domain=None, range=Optional[Union[dict, DefinedTerm]])
+                   model_uri=DCATAPPLUS.rdf_type, domain=None, range=Optional[Union[dict, DefinedTerm]])
 
 slots.realized_plan = Slot(uri=PROV.used, name="realized_plan", curie=PROV.curie('used'),
-                   model_uri=DCATAP_PLUS.realized_plan, domain=None, range=Optional[Union[dict, Plan]])
+                   model_uri=DCATAPPLUS.realized_plan, domain=None, range=Optional[Union[dict, Plan]])
 
 slots.record = Slot(uri=DCAT.record, name="record", curie=DCAT.curie('record'),
-                   model_uri=DCATAP_PLUS.record, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.record, domain=None, range=Optional[str])
 
 slots.related_resource = Slot(uri=DCTERMS.relation, name="related_resource", curie=DCTERMS.curie('relation'),
-                   model_uri=DCATAP_PLUS.related_resource, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.related_resource, domain=None, range=Optional[str])
 
 slots.relation = Slot(uri=DCTERMS.relation, name="relation", curie=DCTERMS.curie('relation'),
-                   model_uri=DCATAP_PLUS.relation, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.relation, domain=None, range=Optional[str])
 
 slots.release_date = Slot(uri=DCTERMS.issued, name="release_date", curie=DCTERMS.curie('issued'),
-                   model_uri=DCATAP_PLUS.release_date, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.release_date, domain=None, range=Optional[str])
 
 slots.rights = Slot(uri=DCTERMS.rights, name="rights", curie=DCTERMS.curie('rights'),
-                   model_uri=DCATAP_PLUS.rights, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.rights, domain=None, range=Optional[str])
 
 slots.sample = Slot(uri=ADMS.sample, name="sample", curie=ADMS.curie('sample'),
-                   model_uri=DCATAP_PLUS.sample, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.sample, domain=None, range=Optional[str])
 
 slots.serves_dataset = Slot(uri=DCAT.servesDataset, name="serves_dataset", curie=DCAT.curie('servesDataset'),
-                   model_uri=DCATAP_PLUS.serves_dataset, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.serves_dataset, domain=None, range=Optional[str])
 
 slots.service = Slot(uri=DCAT.service, name="service", curie=DCAT.curie('service'),
-                   model_uri=DCATAP_PLUS.service, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.service, domain=None, range=Optional[str])
 
 slots.source = Slot(uri=DCTERMS.source, name="source", curie=DCTERMS.curie('source'),
-                   model_uri=DCATAP_PLUS.source, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.source, domain=None, range=Optional[str])
 
 slots.source_metadata = Slot(uri=DCTERMS.source, name="source_metadata", curie=DCTERMS.curie('source'),
-                   model_uri=DCATAP_PLUS.source_metadata, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.source_metadata, domain=None, range=Optional[str])
 
 slots.spatial_resolution = Slot(uri=DCAT.spatialResolutionInMeters, name="spatial_resolution", curie=DCAT.curie('spatialResolutionInMeters'),
-                   model_uri=DCATAP_PLUS.spatial_resolution, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.spatial_resolution, domain=None, range=Optional[str])
 
 slots.start_date = Slot(uri=DCAT.startDate, name="start_date", curie=DCAT.curie('startDate'),
-                   model_uri=DCATAP_PLUS.start_date, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.start_date, domain=None, range=Optional[str])
 
 slots.status = Slot(uri=ADMS.status, name="status", curie=ADMS.curie('status'),
-                   model_uri=DCATAP_PLUS.status, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.status, domain=None, range=Optional[str])
 
 slots.temporal_coverage = Slot(uri=DCTERMS.temporal, name="temporal_coverage", curie=DCTERMS.curie('temporal'),
-                   model_uri=DCATAP_PLUS.temporal_coverage, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.temporal_coverage, domain=None, range=Optional[str])
 
 slots.temporal_resolution = Slot(uri=DCAT.temporalResolution, name="temporal_resolution", curie=DCAT.curie('temporalResolution'),
-                   model_uri=DCATAP_PLUS.temporal_resolution, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.temporal_resolution, domain=None, range=Optional[str])
 
 slots.theme = Slot(uri=DCAT.theme, name="theme", curie=DCAT.curie('theme'),
-                   model_uri=DCATAP_PLUS.theme, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.theme, domain=None, range=Optional[str])
 
 slots.themes = Slot(uri=DCAT.themeTaxonomy, name="themes", curie=DCAT.curie('themeTaxonomy'),
-                   model_uri=DCATAP_PLUS.themes, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.themes, domain=None, range=Optional[str])
 
 slots.title = Slot(uri=DCTERMS.title, name="title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.title, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.title, domain=None, range=Optional[str])
 
 slots.type = Slot(uri=DCTERMS.type, name="type", curie=DCTERMS.curie('type'),
-                   model_uri=DCATAP_PLUS.type, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.type, domain=None, range=Optional[str])
 
 slots.value = Slot(uri=PROV.value, name="value", curie=PROV.curie('value'),
-                   model_uri=DCATAP_PLUS.value, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.value, domain=None, range=Optional[str])
 
 slots.version = Slot(uri=DCAT.version, name="version", curie=DCAT.curie('version'),
-                   model_uri=DCATAP_PLUS.version, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.version, domain=None, range=Optional[str])
 
 slots.version_notes = Slot(uri=ADMS.versionNotes, name="version_notes", curie=ADMS.curie('versionNotes'),
-                   model_uri=DCATAP_PLUS.version_notes, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.version_notes, domain=None, range=Optional[str])
 
 slots.was_generated_by = Slot(uri=PROV.wasGeneratedBy, name="was_generated_by", curie=PROV.curie('wasGeneratedBy'),
-                   model_uri=DCATAP_PLUS.was_generated_by, domain=None, range=Optional[str])
+                   model_uri=DCATAPPLUS.was_generated_by, domain=None, range=Optional[str])
 
 slots.definedTerm__from_CV = Slot(uri=SCHEMA.inDefinedTermSet, name="definedTerm__from_CV", curie=SCHEMA.curie('inDefinedTermSet'),
-                   model_uri=DCATAP_PLUS.definedTerm__from_CV, domain=None, range=Optional[Union[str, URIorCURIE]])
+                   model_uri=DCATAPPLUS.definedTerm__from_CV, domain=None, range=Optional[Union[str, URIorCURIE]])
 
 slots.quantitativeAttribute__has_quantity_type = Slot(uri=QUDT.hasQuantityKind, name="quantitativeAttribute__has_quantity_type", curie=QUDT.curie('hasQuantityKind'),
-                   model_uri=DCATAP_PLUS.quantitativeAttribute__has_quantity_type, domain=None, range=Union[str, DefinedTermId])
+                   model_uri=DCATAPPLUS.quantitativeAttribute__has_quantity_type, domain=None, range=Union[str, DefinedTermId])
 
 slots.quantitativeAttribute__unit = Slot(uri=QUDT.unit, name="quantitativeAttribute__unit", curie=QUDT.curie('unit'),
-                   model_uri=DCATAP_PLUS.quantitativeAttribute__unit, domain=None, range=Optional[Union[str, DefinedTermId]])
+                   model_uri=DCATAPPLUS.quantitativeAttribute__unit, domain=None, range=Optional[Union[str, DefinedTermId]])
 
 slots.Activity_title = Slot(uri=DCTERMS.title, name="Activity_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.Activity_title, domain=Activity, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.Activity_title, domain=Activity, range=Optional[Union[str, list[str]]])
 
 slots.Activity_description = Slot(uri=DCTERMS.description, name="Activity_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.Activity_description, domain=Activity, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.Activity_description, domain=Activity, range=Optional[Union[str, list[str]]])
 
 slots.Activity_has_part = Slot(uri=DCTERMS.hasPart, name="Activity_has_part", curie=DCTERMS.curie('hasPart'),
-                   model_uri=DCATAP_PLUS.Activity_has_part, domain=Activity, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, "Activity"]], list[Union[dict, "Activity"]]]])
+                   model_uri=DCATAPPLUS.Activity_has_part, domain=Activity, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, "Activity"]], list[Union[dict, "Activity"]]]])
 
 slots.Activity_part_of = Slot(uri=DCTERMS.isPartOf, name="Activity_part_of", curie=DCTERMS.curie('isPartOf'),
-                   model_uri=DCATAP_PLUS.Activity_part_of, domain=Activity, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, "Activity"]], list[Union[dict, "Activity"]]]])
+                   model_uri=DCATAPPLUS.Activity_part_of, domain=Activity, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, "Activity"]], list[Union[dict, "Activity"]]]])
 
 slots.Activity_other_identifier = Slot(uri=ADMS.identifier, name="Activity_other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.Activity_other_identifier, domain=Activity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
+                   model_uri=DCATAPPLUS.Activity_other_identifier, domain=Activity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
 
 slots.Activity_has_qualitative_attribute = Slot(uri=DCTERMS.relation, name="Activity_has_qualitative_attribute", curie=DCTERMS.curie('relation'),
-                   model_uri=DCATAP_PLUS.Activity_has_qualitative_attribute, domain=Activity, range=Optional[Union[Union[dict, "QualitativeAttribute"], list[Union[dict, "QualitativeAttribute"]]]])
+                   model_uri=DCATAPPLUS.Activity_has_qualitative_attribute, domain=Activity, range=Optional[Union[Union[dict, "QualitativeAttribute"], list[Union[dict, "QualitativeAttribute"]]]])
 
 slots.Activity_has_quantitative_attribute = Slot(uri=DCTERMS.relation, name="Activity_has_quantitative_attribute", curie=DCTERMS.curie('relation'),
-                   model_uri=DCATAP_PLUS.Activity_has_quantitative_attribute, domain=Activity, range=Optional[Union[Union[dict, "QuantitativeAttribute"], list[Union[dict, "QuantitativeAttribute"]]]])
+                   model_uri=DCATAPPLUS.Activity_has_quantitative_attribute, domain=Activity, range=Optional[Union[Union[dict, "QuantitativeAttribute"], list[Union[dict, "QuantitativeAttribute"]]]])
 
 slots.Activity_had_input_entity = Slot(uri=PROV.used, name="Activity_had_input_entity", curie=PROV.curie('used'),
-                   model_uri=DCATAP_PLUS.Activity_had_input_entity, domain=Activity, range=Optional[Union[dict[Union[str, EntityId], Union[dict, "Entity"]], list[Union[dict, "Entity"]]]])
+                   model_uri=DCATAPPLUS.Activity_had_input_entity, domain=Activity, range=Optional[Union[dict[Union[str, EntityId], Union[dict, "Entity"]], list[Union[dict, "Entity"]]]])
 
 slots.Activity_had_output_entity = Slot(uri=PROV.generated, name="Activity_had_output_entity", curie=PROV.curie('generated'),
-                   model_uri=DCATAP_PLUS.Activity_had_output_entity, domain=Activity, range=Optional[Union[dict[Union[str, EntityId], Union[dict, "Entity"]], list[Union[dict, "Entity"]]]])
+                   model_uri=DCATAPPLUS.Activity_had_output_entity, domain=Activity, range=Optional[Union[dict[Union[str, EntityId], Union[dict, "Entity"]], list[Union[dict, "Entity"]]]])
 
 slots.Activity_had_input_activity = Slot(uri=PROV.wasInformedBy, name="Activity_had_input_activity", curie=PROV.curie('wasInformedBy'),
-                   model_uri=DCATAP_PLUS.Activity_had_input_activity, domain=Activity, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, "Activity"]], list[Union[dict, "Activity"]]]])
+                   model_uri=DCATAPPLUS.Activity_had_input_activity, domain=Activity, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, "Activity"]], list[Union[dict, "Activity"]]]])
 
 slots.Activity_carried_out_by = Slot(uri=PROV.wasAssociatedWith, name="Activity_carried_out_by", curie=PROV.curie('wasAssociatedWith'),
-                   model_uri=DCATAP_PLUS.Activity_carried_out_by, domain=Activity, range=Optional[Union[dict[Union[str, AgenticEntityId], Union[dict, "AgenticEntity"]], list[Union[dict, "AgenticEntity"]]]])
+                   model_uri=DCATAPPLUS.Activity_carried_out_by, domain=Activity, range=Optional[Union[dict[Union[str, AgenticEntityId], Union[dict, "AgenticEntity"]], list[Union[dict, "AgenticEntity"]]]])
 
 slots.Agent_name = Slot(uri=FOAF.name, name="Agent_name", curie=FOAF.curie('name'),
-                   model_uri=DCATAP_PLUS.Agent_name, domain=Agent, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.Agent_name, domain=Agent, range=Union[str, list[str]])
 
 slots.Agent_type = Slot(uri=DCTERMS.type, name="Agent_type", curie=DCTERMS.curie('type'),
-                   model_uri=DCATAP_PLUS.Agent_type, domain=Agent, range=Optional[Union[dict, "Concept"]])
+                   model_uri=DCATAPPLUS.Agent_type, domain=Agent, range=Optional[Union[dict, "Concept"]])
 
 slots.AgenticEntity_has_part = Slot(uri=DCTERMS.hasPart, name="AgenticEntity_has_part", curie=DCTERMS.curie('hasPart'),
-                   model_uri=DCATAP_PLUS.AgenticEntity_has_part, domain=AgenticEntity, range=Optional[Union[dict[Union[str, AgenticEntityId], Union[dict, "AgenticEntity"]], list[Union[dict, "AgenticEntity"]]]])
+                   model_uri=DCATAPPLUS.AgenticEntity_has_part, domain=AgenticEntity, range=Optional[Union[dict[Union[str, AgenticEntityId], Union[dict, "AgenticEntity"]], list[Union[dict, "AgenticEntity"]]]])
 
 slots.AgenticEntity_part_of = Slot(uri=DCTERMS.isPartOf, name="AgenticEntity_part_of", curie=DCTERMS.curie('isPartOf'),
-                   model_uri=DCATAP_PLUS.AgenticEntity_part_of, domain=AgenticEntity, range=Optional[Union[dict[Union[str, AgenticEntityId], Union[dict, "AgenticEntity"]], list[Union[dict, "AgenticEntity"]]]])
+                   model_uri=DCATAPPLUS.AgenticEntity_part_of, domain=AgenticEntity, range=Optional[Union[dict[Union[str, AgenticEntityId], Union[dict, "AgenticEntity"]], list[Union[dict, "AgenticEntity"]]]])
 
 slots.AgenticEntity_other_identifier = Slot(uri=ADMS.identifier, name="AgenticEntity_other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.AgenticEntity_other_identifier, domain=AgenticEntity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
+                   model_uri=DCATAPPLUS.AgenticEntity_other_identifier, domain=AgenticEntity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
 
 slots.AnalysisDataset_was_generated_by = Slot(uri=PROV.wasGeneratedBy, name="AnalysisDataset_was_generated_by", curie=PROV.curie('wasGeneratedBy'),
-                   model_uri=DCATAP_PLUS.AnalysisDataset_was_generated_by, domain=AnalysisDataset, range=Optional[Union[dict[Union[str, DataAnalysisId], Union[dict, DataAnalysis]], list[Union[dict, DataAnalysis]]]])
+                   model_uri=DCATAPPLUS.AnalysisDataset_was_generated_by, domain=AnalysisDataset, range=Optional[Union[dict[Union[str, DataAnalysisId], Union[dict, DataAnalysis]], list[Union[dict, DataAnalysis]]]])
 
 slots.AnalysisSourceData_was_generated_by = Slot(uri=PROV.wasGeneratedBy, name="AnalysisSourceData_was_generated_by", curie=PROV.curie('wasGeneratedBy'),
-                   model_uri=DCATAP_PLUS.AnalysisSourceData_was_generated_by, domain=AnalysisSourceData, range=Optional[Union[dict[Union[str, DataGeneratingActivityId], Union[dict, DataGeneratingActivity]], list[Union[dict, DataGeneratingActivity]]]])
+                   model_uri=DCATAPPLUS.AnalysisSourceData_was_generated_by, domain=AnalysisSourceData, range=Optional[Union[dict[Union[str, DataGeneratingActivityId], Union[dict, DataGeneratingActivity]], list[Union[dict, DataGeneratingActivity]]]])
 
 slots.Catalogue_applicable_legislation = Slot(uri=DCATAP.applicableLegislation, name="Catalogue_applicable_legislation", curie=DCATAP.curie('applicableLegislation'),
-                   model_uri=DCATAP_PLUS.Catalogue_applicable_legislation, domain=Catalogue, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_applicable_legislation, domain=Catalogue, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
 
 slots.Catalogue_catalogue = Slot(uri=DCAT.catalog, name="Catalogue_catalogue", curie=DCAT.curie('catalog'),
-                   model_uri=DCATAP_PLUS.Catalogue_catalogue, domain=Catalogue, range=Optional[Union[Union[dict, "Catalogue"], list[Union[dict, "Catalogue"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_catalogue, domain=Catalogue, range=Optional[Union[Union[dict, "Catalogue"], list[Union[dict, "Catalogue"]]]])
 
 slots.Catalogue_creator = Slot(uri=DCTERMS.creator, name="Catalogue_creator", curie=DCTERMS.curie('creator'),
-                   model_uri=DCATAP_PLUS.Catalogue_creator, domain=Catalogue, range=Optional[Union[dict, Agent]])
+                   model_uri=DCATAPPLUS.Catalogue_creator, domain=Catalogue, range=Optional[Union[dict, Agent]])
 
 slots.Catalogue_description = Slot(uri=DCTERMS.description, name="Catalogue_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.Catalogue_description, domain=Catalogue, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.Catalogue_description, domain=Catalogue, range=Union[str, list[str]])
 
 slots.Catalogue_geographical_coverage = Slot(uri=DCTERMS.spatial, name="Catalogue_geographical_coverage", curie=DCTERMS.curie('spatial'),
-                   model_uri=DCATAP_PLUS.Catalogue_geographical_coverage, domain=Catalogue, range=Optional[Union[Union[dict, "Location"], list[Union[dict, "Location"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_geographical_coverage, domain=Catalogue, range=Optional[Union[Union[dict, "Location"], list[Union[dict, "Location"]]]])
 
 slots.Catalogue_has_dataset = Slot(uri=DCAT.dataset, name="Catalogue_has_dataset", curie=DCAT.curie('dataset'),
-                   model_uri=DCATAP_PLUS.Catalogue_has_dataset, domain=Catalogue, range=Optional[Union[dict[Union[str, DatasetId], Union[dict, "Dataset"]], list[Union[dict, "Dataset"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_has_dataset, domain=Catalogue, range=Optional[Union[dict[Union[str, DatasetId], Union[dict, "Dataset"]], list[Union[dict, "Dataset"]]]])
 
 slots.Catalogue_has_part = Slot(uri=DCTERMS.hasPart, name="Catalogue_has_part", curie=DCTERMS.curie('hasPart'),
-                   model_uri=DCATAP_PLUS.Catalogue_has_part, domain=Catalogue, range=Optional[Union[Union[dict, "Catalogue"], list[Union[dict, "Catalogue"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_has_part, domain=Catalogue, range=Optional[Union[Union[dict, "Catalogue"], list[Union[dict, "Catalogue"]]]])
 
 slots.Catalogue_homepage = Slot(uri=FOAF.homepage, name="Catalogue_homepage", curie=FOAF.curie('homepage'),
-                   model_uri=DCATAP_PLUS.Catalogue_homepage, domain=Catalogue, range=Optional[Union[dict, "Document"]])
+                   model_uri=DCATAPPLUS.Catalogue_homepage, domain=Catalogue, range=Optional[Union[dict, "Document"]])
 
 slots.Catalogue_language = Slot(uri=DCTERMS.language, name="Catalogue_language", curie=DCTERMS.curie('language'),
-                   model_uri=DCATAP_PLUS.Catalogue_language, domain=Catalogue, range=Optional[Union[Union[dict, "LinguisticSystem"], list[Union[dict, "LinguisticSystem"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_language, domain=Catalogue, range=Optional[Union[Union[dict, "LinguisticSystem"], list[Union[dict, "LinguisticSystem"]]]])
 
 slots.Catalogue_licence = Slot(uri=DCTERMS.license, name="Catalogue_licence", curie=DCTERMS.curie('license'),
-                   model_uri=DCATAP_PLUS.Catalogue_licence, domain=Catalogue, range=Optional[Union[dict, "LicenseDocument"]])
+                   model_uri=DCATAPPLUS.Catalogue_licence, domain=Catalogue, range=Optional[Union[dict, "LicenseDocument"]])
 
 slots.Catalogue_modification_date = Slot(uri=DCTERMS.modified, name="Catalogue_modification_date", curie=DCTERMS.curie('modified'),
-                   model_uri=DCATAP_PLUS.Catalogue_modification_date, domain=Catalogue, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.Catalogue_modification_date, domain=Catalogue, range=Optional[Union[str, XSDDate]])
 
 slots.Catalogue_publisher = Slot(uri=DCTERMS.publisher, name="Catalogue_publisher", curie=DCTERMS.curie('publisher'),
-                   model_uri=DCATAP_PLUS.Catalogue_publisher, domain=Catalogue, range=Union[dict, Agent])
+                   model_uri=DCATAPPLUS.Catalogue_publisher, domain=Catalogue, range=Union[dict, Agent])
 
 slots.Catalogue_record = Slot(uri=DCAT.record, name="Catalogue_record", curie=DCAT.curie('record'),
-                   model_uri=DCATAP_PLUS.Catalogue_record, domain=Catalogue, range=Optional[Union[Union[dict, "CatalogueRecord"], list[Union[dict, "CatalogueRecord"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_record, domain=Catalogue, range=Optional[Union[Union[dict, "CatalogueRecord"], list[Union[dict, "CatalogueRecord"]]]])
 
 slots.Catalogue_release_date = Slot(uri=DCTERMS.issued, name="Catalogue_release_date", curie=DCTERMS.curie('issued'),
-                   model_uri=DCATAP_PLUS.Catalogue_release_date, domain=Catalogue, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.Catalogue_release_date, domain=Catalogue, range=Optional[Union[str, XSDDate]])
 
 slots.Catalogue_rights = Slot(uri=DCTERMS.rights, name="Catalogue_rights", curie=DCTERMS.curie('rights'),
-                   model_uri=DCATAP_PLUS.Catalogue_rights, domain=Catalogue, range=Optional[Union[dict, "RightsStatement"]])
+                   model_uri=DCATAPPLUS.Catalogue_rights, domain=Catalogue, range=Optional[Union[dict, "RightsStatement"]])
 
 slots.Catalogue_service = Slot(uri=DCAT.service, name="Catalogue_service", curie=DCAT.curie('service'),
-                   model_uri=DCATAP_PLUS.Catalogue_service, domain=Catalogue, range=Optional[Union[Union[dict, "DataService"], list[Union[dict, "DataService"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_service, domain=Catalogue, range=Optional[Union[Union[dict, "DataService"], list[Union[dict, "DataService"]]]])
 
 slots.Catalogue_temporal_coverage = Slot(uri=DCTERMS.temporal, name="Catalogue_temporal_coverage", curie=DCTERMS.curie('temporal'),
-                   model_uri=DCATAP_PLUS.Catalogue_temporal_coverage, domain=Catalogue, range=Optional[Union[Union[dict, "PeriodOfTime"], list[Union[dict, "PeriodOfTime"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_temporal_coverage, domain=Catalogue, range=Optional[Union[Union[dict, "PeriodOfTime"], list[Union[dict, "PeriodOfTime"]]]])
 
 slots.Catalogue_themes = Slot(uri=DCAT.themeTaxonomy, name="Catalogue_themes", curie=DCAT.curie('themeTaxonomy'),
-                   model_uri=DCATAP_PLUS.Catalogue_themes, domain=Catalogue, range=Optional[Union[Union[dict, "ConceptScheme"], list[Union[dict, "ConceptScheme"]]]])
+                   model_uri=DCATAPPLUS.Catalogue_themes, domain=Catalogue, range=Optional[Union[Union[dict, "ConceptScheme"], list[Union[dict, "ConceptScheme"]]]])
 
 slots.Catalogue_title = Slot(uri=DCTERMS.title, name="Catalogue_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.Catalogue_title, domain=Catalogue, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.Catalogue_title, domain=Catalogue, range=Union[str, list[str]])
 
 slots.CatalogueRecord_application_profile = Slot(uri=DCTERMS.conformsTo, name="CatalogueRecord_application_profile", curie=DCTERMS.curie('conformsTo'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_application_profile, domain=CatalogueRecord, range=Optional[Union[Union[dict, "Standard"], list[Union[dict, "Standard"]]]])
+                   model_uri=DCATAPPLUS.CatalogueRecord_application_profile, domain=CatalogueRecord, range=Optional[Union[Union[dict, "Standard"], list[Union[dict, "Standard"]]]])
 
 slots.CatalogueRecord_change_type = Slot(uri=ADMS.status, name="CatalogueRecord_change_type", curie=ADMS.curie('status'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_change_type, domain=CatalogueRecord, range=Optional[Union[dict, "Concept"]])
+                   model_uri=DCATAPPLUS.CatalogueRecord_change_type, domain=CatalogueRecord, range=Optional[Union[dict, "Concept"]])
 
 slots.CatalogueRecord_description = Slot(uri=DCTERMS.description, name="CatalogueRecord_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_description, domain=CatalogueRecord, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.CatalogueRecord_description, domain=CatalogueRecord, range=Optional[Union[str, list[str]]])
 
 slots.CatalogueRecord_language = Slot(uri=DCTERMS.language, name="CatalogueRecord_language", curie=DCTERMS.curie('language'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_language, domain=CatalogueRecord, range=Optional[Union[Union[dict, "LinguisticSystem"], list[Union[dict, "LinguisticSystem"]]]])
+                   model_uri=DCATAPPLUS.CatalogueRecord_language, domain=CatalogueRecord, range=Optional[Union[Union[dict, "LinguisticSystem"], list[Union[dict, "LinguisticSystem"]]]])
 
 slots.CatalogueRecord_listing_date = Slot(uri=DCTERMS.issued, name="CatalogueRecord_listing_date", curie=DCTERMS.curie('issued'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_listing_date, domain=CatalogueRecord, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.CatalogueRecord_listing_date, domain=CatalogueRecord, range=Optional[Union[str, XSDDate]])
 
 slots.CatalogueRecord_modification_date = Slot(uri=DCTERMS.modified, name="CatalogueRecord_modification_date", curie=DCTERMS.curie('modified'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_modification_date, domain=CatalogueRecord, range=Union[str, XSDDate])
+                   model_uri=DCATAPPLUS.CatalogueRecord_modification_date, domain=CatalogueRecord, range=Union[str, XSDDate])
 
 slots.CatalogueRecord_primary_topic = Slot(uri=FOAF.primaryTopic, name="CatalogueRecord_primary_topic", curie=FOAF.curie('primaryTopic'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_primary_topic, domain=CatalogueRecord, range=Union[dict, Any])
+                   model_uri=DCATAPPLUS.CatalogueRecord_primary_topic, domain=CatalogueRecord, range=Union[dict, Any])
 
 slots.CatalogueRecord_source_metadata = Slot(uri=DCTERMS.source, name="CatalogueRecord_source_metadata", curie=DCTERMS.curie('source'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_source_metadata, domain=CatalogueRecord, range=Optional[Union[dict, "CatalogueRecord"]])
+                   model_uri=DCATAPPLUS.CatalogueRecord_source_metadata, domain=CatalogueRecord, range=Optional[Union[dict, "CatalogueRecord"]])
 
 slots.CatalogueRecord_title = Slot(uri=DCTERMS.title, name="CatalogueRecord_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.CatalogueRecord_title, domain=CatalogueRecord, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.CatalogueRecord_title, domain=CatalogueRecord, range=Optional[Union[str, list[str]]])
 
 slots.Checksum_algorithm = Slot(uri=SPDX.algorithm, name="Checksum_algorithm", curie=SPDX.curie('algorithm'),
-                   model_uri=DCATAP_PLUS.Checksum_algorithm, domain=Checksum, range=Union[dict, "ChecksumAlgorithm"])
+                   model_uri=DCATAPPLUS.Checksum_algorithm, domain=Checksum, range=Union[dict, "ChecksumAlgorithm"])
 
 slots.Checksum_checksum_value = Slot(uri=SPDX.checksumValue, name="Checksum_checksum_value", curie=SPDX.curie('checksumValue'),
-                   model_uri=DCATAP_PLUS.Checksum_checksum_value, domain=Checksum, range=str)
+                   model_uri=DCATAPPLUS.Checksum_checksum_value, domain=Checksum, range=str)
 
 slots.ClassifierMixin_type = Slot(uri=DCTERMS.type, name="ClassifierMixin_type", curie=DCTERMS.curie('type'),
-                   model_uri=DCATAP_PLUS.ClassifierMixin_type, domain=None, range=Optional[Union[dict, "DefinedTerm"]])
+                   model_uri=DCATAPPLUS.ClassifierMixin_type, domain=None, range=Optional[Union[dict, "DefinedTerm"]])
 
 slots.Concept_preferred_label = Slot(uri=SKOS.prefLabel, name="Concept_preferred_label", curie=SKOS.curie('prefLabel'),
-                   model_uri=DCATAP_PLUS.Concept_preferred_label, domain=Concept, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.Concept_preferred_label, domain=Concept, range=Union[str, list[str]])
 
 slots.ConceptScheme_title = Slot(uri=DCTERMS.title, name="ConceptScheme_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.ConceptScheme_title, domain=ConceptScheme, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.ConceptScheme_title, domain=ConceptScheme, range=Union[str, list[str]])
 
 slots.DataAnalysis_evaluated_entity = Slot(uri=PROV.used, name="DataAnalysis_evaluated_entity", curie=PROV.curie('used'),
-                   model_uri=DCATAP_PLUS.DataAnalysis_evaluated_entity, domain=DataAnalysis, range=Optional[Union[dict[Union[str, AnalysisSourceDataId], Union[dict, "AnalysisSourceData"]], list[Union[dict, "AnalysisSourceData"]]]])
+                   model_uri=DCATAPPLUS.DataAnalysis_evaluated_entity, domain=DataAnalysis, range=Optional[Union[dict[Union[str, AnalysisSourceDataId], Union[dict, "AnalysisSourceData"]], list[Union[dict, "AnalysisSourceData"]]]])
 
 slots.DataService_access_rights = Slot(uri=DCTERMS.accessRights, name="DataService_access_rights", curie=DCTERMS.curie('accessRights'),
-                   model_uri=DCATAP_PLUS.DataService_access_rights, domain=DataService, range=Optional[Union[dict, "RightsStatement"]])
+                   model_uri=DCATAPPLUS.DataService_access_rights, domain=DataService, range=Optional[Union[dict, "RightsStatement"]])
 
 slots.DataService_applicable_legislation = Slot(uri=DCATAP.applicableLegislation, name="DataService_applicable_legislation", curie=DCATAP.curie('applicableLegislation'),
-                   model_uri=DCATAP_PLUS.DataService_applicable_legislation, domain=DataService, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
+                   model_uri=DCATAPPLUS.DataService_applicable_legislation, domain=DataService, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
 
 slots.DataService_conforms_to = Slot(uri=DCTERMS.conformsTo, name="DataService_conforms_to", curie=DCTERMS.curie('conformsTo'),
-                   model_uri=DCATAP_PLUS.DataService_conforms_to, domain=DataService, range=Optional[Union[Union[dict, "Standard"], list[Union[dict, "Standard"]]]])
+                   model_uri=DCATAPPLUS.DataService_conforms_to, domain=DataService, range=Optional[Union[Union[dict, "Standard"], list[Union[dict, "Standard"]]]])
 
 slots.DataService_contact_point = Slot(uri=DCAT.contactPoint, name="DataService_contact_point", curie=DCAT.curie('contactPoint'),
-                   model_uri=DCATAP_PLUS.DataService_contact_point, domain=DataService, range=Optional[Union[Union[dict, "Kind"], list[Union[dict, "Kind"]]]])
+                   model_uri=DCATAPPLUS.DataService_contact_point, domain=DataService, range=Optional[Union[Union[dict, "Kind"], list[Union[dict, "Kind"]]]])
 
 slots.DataService_description = Slot(uri=DCTERMS.description, name="DataService_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.DataService_description, domain=DataService, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.DataService_description, domain=DataService, range=Optional[Union[str, list[str]]])
 
 slots.DataService_documentation = Slot(uri=FOAF.page, name="DataService_documentation", curie=FOAF.curie('page'),
-                   model_uri=DCATAP_PLUS.DataService_documentation, domain=DataService, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
+                   model_uri=DCATAPPLUS.DataService_documentation, domain=DataService, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
 
 slots.DataService_endpoint_URL = Slot(uri=DCAT.endpointURL, name="DataService_endpoint_URL", curie=DCAT.curie('endpointURL'),
-                   model_uri=DCATAP_PLUS.DataService_endpoint_URL, domain=DataService, range=Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]])
+                   model_uri=DCATAPPLUS.DataService_endpoint_URL, domain=DataService, range=Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]])
 
 slots.DataService_endpoint_description = Slot(uri=DCAT.endpointDescription, name="DataService_endpoint_description", curie=DCAT.curie('endpointDescription'),
-                   model_uri=DCATAP_PLUS.DataService_endpoint_description, domain=DataService, range=Optional[Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]]])
+                   model_uri=DCATAPPLUS.DataService_endpoint_description, domain=DataService, range=Optional[Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]]])
 
 slots.DataService_format = Slot(uri=DCTERMS.format, name="DataService_format", curie=DCTERMS.curie('format'),
-                   model_uri=DCATAP_PLUS.DataService_format, domain=DataService, range=Optional[Union[Union[dict, "MediaTypeOrExtent"], list[Union[dict, "MediaTypeOrExtent"]]]])
+                   model_uri=DCATAPPLUS.DataService_format, domain=DataService, range=Optional[Union[Union[dict, "MediaTypeOrExtent"], list[Union[dict, "MediaTypeOrExtent"]]]])
 
 slots.DataService_keyword = Slot(uri=DCAT.keyword, name="DataService_keyword", curie=DCAT.curie('keyword'),
-                   model_uri=DCATAP_PLUS.DataService_keyword, domain=DataService, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.DataService_keyword, domain=DataService, range=Optional[Union[str, list[str]]])
 
 slots.DataService_landing_page = Slot(uri=DCAT.landingPage, name="DataService_landing_page", curie=DCAT.curie('landingPage'),
-                   model_uri=DCATAP_PLUS.DataService_landing_page, domain=DataService, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
+                   model_uri=DCATAPPLUS.DataService_landing_page, domain=DataService, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
 
 slots.DataService_licence = Slot(uri=DCTERMS.license, name="DataService_licence", curie=DCTERMS.curie('license'),
-                   model_uri=DCATAP_PLUS.DataService_licence, domain=DataService, range=Optional[Union[dict, "LicenseDocument"]])
+                   model_uri=DCATAPPLUS.DataService_licence, domain=DataService, range=Optional[Union[dict, "LicenseDocument"]])
 
 slots.DataService_publisher = Slot(uri=DCTERMS.publisher, name="DataService_publisher", curie=DCTERMS.curie('publisher'),
-                   model_uri=DCATAP_PLUS.DataService_publisher, domain=DataService, range=Optional[Union[dict, Agent]])
+                   model_uri=DCATAPPLUS.DataService_publisher, domain=DataService, range=Optional[Union[dict, Agent]])
 
 slots.DataService_serves_dataset = Slot(uri=DCAT.servesDataset, name="DataService_serves_dataset", curie=DCAT.curie('servesDataset'),
-                   model_uri=DCATAP_PLUS.DataService_serves_dataset, domain=DataService, range=Optional[Union[dict[Union[str, DatasetId], Union[dict, "Dataset"]], list[Union[dict, "Dataset"]]]])
+                   model_uri=DCATAPPLUS.DataService_serves_dataset, domain=DataService, range=Optional[Union[dict[Union[str, DatasetId], Union[dict, "Dataset"]], list[Union[dict, "Dataset"]]]])
 
 slots.DataService_theme = Slot(uri=DCAT.theme, name="DataService_theme", curie=DCAT.curie('theme'),
-                   model_uri=DCATAP_PLUS.DataService_theme, domain=DataService, range=Optional[Union[Union[dict, "Concept"], list[Union[dict, "Concept"]]]])
+                   model_uri=DCATAPPLUS.DataService_theme, domain=DataService, range=Optional[Union[Union[dict, "Concept"], list[Union[dict, "Concept"]]]])
 
 slots.DataService_title = Slot(uri=DCTERMS.title, name="DataService_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.DataService_title, domain=DataService, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.DataService_title, domain=DataService, range=Union[str, list[str]])
 
 slots.Dataset_access_rights = Slot(uri=DCTERMS.accessRights, name="Dataset_access_rights", curie=DCTERMS.curie('accessRights'),
-                   model_uri=DCATAP_PLUS.Dataset_access_rights, domain=Dataset, range=Optional[Union[dict, "RightsStatement"]])
+                   model_uri=DCATAPPLUS.Dataset_access_rights, domain=Dataset, range=Optional[Union[dict, "RightsStatement"]])
 
 slots.Dataset_applicable_legislation = Slot(uri=DCATAP.applicableLegislation, name="Dataset_applicable_legislation", curie=DCATAP.curie('applicableLegislation'),
-                   model_uri=DCATAP_PLUS.Dataset_applicable_legislation, domain=Dataset, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
+                   model_uri=DCATAPPLUS.Dataset_applicable_legislation, domain=Dataset, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
 
 slots.Dataset_conforms_to = Slot(uri=DCTERMS.conformsTo, name="Dataset_conforms_to", curie=DCTERMS.curie('conformsTo'),
-                   model_uri=DCATAP_PLUS.Dataset_conforms_to, domain=Dataset, range=Optional[Union[Union[dict, "Standard"], list[Union[dict, "Standard"]]]])
+                   model_uri=DCATAPPLUS.Dataset_conforms_to, domain=Dataset, range=Optional[Union[Union[dict, "Standard"], list[Union[dict, "Standard"]]]])
 
 slots.Dataset_contact_point = Slot(uri=DCAT.contactPoint, name="Dataset_contact_point", curie=DCAT.curie('contactPoint'),
-                   model_uri=DCATAP_PLUS.Dataset_contact_point, domain=Dataset, range=Optional[Union[Union[dict, "Kind"], list[Union[dict, "Kind"]]]])
+                   model_uri=DCATAPPLUS.Dataset_contact_point, domain=Dataset, range=Optional[Union[Union[dict, "Kind"], list[Union[dict, "Kind"]]]])
 
 slots.Dataset_creator = Slot(uri=DCTERMS.creator, name="Dataset_creator", curie=DCTERMS.curie('creator'),
-                   model_uri=DCATAP_PLUS.Dataset_creator, domain=Dataset, range=Optional[Union[Union[dict, Agent], list[Union[dict, Agent]]]])
+                   model_uri=DCATAPPLUS.Dataset_creator, domain=Dataset, range=Optional[Union[Union[dict, Agent], list[Union[dict, Agent]]]])
 
 slots.Dataset_dataset_distribution = Slot(uri=DCAT.distribution, name="Dataset_dataset_distribution", curie=DCAT.curie('distribution'),
-                   model_uri=DCATAP_PLUS.Dataset_dataset_distribution, domain=Dataset, range=Optional[Union[Union[dict, "Distribution"], list[Union[dict, "Distribution"]]]])
+                   model_uri=DCATAPPLUS.Dataset_dataset_distribution, domain=Dataset, range=Optional[Union[Union[dict, "Distribution"], list[Union[dict, "Distribution"]]]])
 
 slots.Dataset_description = Slot(uri=DCTERMS.description, name="Dataset_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.Dataset_description, domain=Dataset, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.Dataset_description, domain=Dataset, range=Union[str, list[str]])
 
 slots.Dataset_documentation = Slot(uri=FOAF.page, name="Dataset_documentation", curie=FOAF.curie('page'),
-                   model_uri=DCATAP_PLUS.Dataset_documentation, domain=Dataset, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
+                   model_uri=DCATAPPLUS.Dataset_documentation, domain=Dataset, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
 
 slots.Dataset_frequency = Slot(uri=DCTERMS.accrualPeriodicity, name="Dataset_frequency", curie=DCTERMS.curie('accrualPeriodicity'),
-                   model_uri=DCATAP_PLUS.Dataset_frequency, domain=Dataset, range=Optional[Union[dict, "Frequency"]])
+                   model_uri=DCATAPPLUS.Dataset_frequency, domain=Dataset, range=Optional[Union[dict, "Frequency"]])
 
 slots.Dataset_geographical_coverage = Slot(uri=DCTERMS.spatial, name="Dataset_geographical_coverage", curie=DCTERMS.curie('spatial'),
-                   model_uri=DCATAP_PLUS.Dataset_geographical_coverage, domain=Dataset, range=Optional[Union[Union[dict, "Location"], list[Union[dict, "Location"]]]])
+                   model_uri=DCATAPPLUS.Dataset_geographical_coverage, domain=Dataset, range=Optional[Union[Union[dict, "Location"], list[Union[dict, "Location"]]]])
 
 slots.Dataset_has_version = Slot(uri=DCAT.hasVersion, name="Dataset_has_version", curie=DCAT.curie('hasVersion'),
-                   model_uri=DCATAP_PLUS.Dataset_has_version, domain=Dataset, range=Optional[Union[dict[Union[str, DatasetId], Union[dict, "Dataset"]], list[Union[dict, "Dataset"]]]])
+                   model_uri=DCATAPPLUS.Dataset_has_version, domain=Dataset, range=Optional[Union[dict[Union[str, DatasetId], Union[dict, "Dataset"]], list[Union[dict, "Dataset"]]]])
 
 slots.Dataset_identifier = Slot(uri=DCTERMS.identifier, name="Dataset_identifier", curie=DCTERMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.Dataset_identifier, domain=Dataset, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.Dataset_identifier, domain=Dataset, range=Optional[Union[str, list[str]]])
 
 slots.Dataset_in_series = Slot(uri=DCAT.inSeries, name="Dataset_in_series", curie=DCAT.curie('inSeries'),
-                   model_uri=DCATAP_PLUS.Dataset_in_series, domain=Dataset, range=Optional[Union[Union[dict, "DatasetSeries"], list[Union[dict, "DatasetSeries"]]]])
+                   model_uri=DCATAPPLUS.Dataset_in_series, domain=Dataset, range=Optional[Union[Union[dict, "DatasetSeries"], list[Union[dict, "DatasetSeries"]]]])
 
 slots.Dataset_is_referenced_by = Slot(uri=DCTERMS.isReferencedBy, name="Dataset_is_referenced_by", curie=DCTERMS.curie('isReferencedBy'),
-                   model_uri=DCATAP_PLUS.Dataset_is_referenced_by, domain=Dataset, range=Optional[Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]]])
+                   model_uri=DCATAPPLUS.Dataset_is_referenced_by, domain=Dataset, range=Optional[Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]]])
 
 slots.Dataset_keyword = Slot(uri=DCAT.keyword, name="Dataset_keyword", curie=DCAT.curie('keyword'),
-                   model_uri=DCATAP_PLUS.Dataset_keyword, domain=Dataset, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.Dataset_keyword, domain=Dataset, range=Optional[Union[str, list[str]]])
 
 slots.Dataset_landing_page = Slot(uri=DCAT.landingPage, name="Dataset_landing_page", curie=DCAT.curie('landingPage'),
-                   model_uri=DCATAP_PLUS.Dataset_landing_page, domain=Dataset, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
+                   model_uri=DCATAPPLUS.Dataset_landing_page, domain=Dataset, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
 
 slots.Dataset_language = Slot(uri=DCTERMS.language, name="Dataset_language", curie=DCTERMS.curie('language'),
-                   model_uri=DCATAP_PLUS.Dataset_language, domain=Dataset, range=Optional[Union[Union[dict, "LinguisticSystem"], list[Union[dict, "LinguisticSystem"]]]])
+                   model_uri=DCATAPPLUS.Dataset_language, domain=Dataset, range=Optional[Union[Union[dict, "LinguisticSystem"], list[Union[dict, "LinguisticSystem"]]]])
 
 slots.Dataset_modification_date = Slot(uri=DCTERMS.modified, name="Dataset_modification_date", curie=DCTERMS.curie('modified'),
-                   model_uri=DCATAP_PLUS.Dataset_modification_date, domain=Dataset, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.Dataset_modification_date, domain=Dataset, range=Optional[Union[str, XSDDate]])
 
 slots.Dataset_other_identifier = Slot(uri=ADMS.identifier, name="Dataset_other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.Dataset_other_identifier, domain=Dataset, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
+                   model_uri=DCATAPPLUS.Dataset_other_identifier, domain=Dataset, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
 
 slots.Dataset_provenance = Slot(uri=DCTERMS.provenance, name="Dataset_provenance", curie=DCTERMS.curie('provenance'),
-                   model_uri=DCATAP_PLUS.Dataset_provenance, domain=Dataset, range=Optional[Union[Union[dict, "ProvenanceStatement"], list[Union[dict, "ProvenanceStatement"]]]])
+                   model_uri=DCATAPPLUS.Dataset_provenance, domain=Dataset, range=Optional[Union[Union[dict, "ProvenanceStatement"], list[Union[dict, "ProvenanceStatement"]]]])
 
 slots.Dataset_publisher = Slot(uri=DCTERMS.publisher, name="Dataset_publisher", curie=DCTERMS.curie('publisher'),
-                   model_uri=DCATAP_PLUS.Dataset_publisher, domain=Dataset, range=Optional[Union[dict, Agent]])
+                   model_uri=DCATAPPLUS.Dataset_publisher, domain=Dataset, range=Optional[Union[dict, Agent]])
 
 slots.Dataset_qualified_attribution = Slot(uri=PROV.qualifiedAttribution, name="Dataset_qualified_attribution", curie=PROV.curie('qualifiedAttribution'),
-                   model_uri=DCATAP_PLUS.Dataset_qualified_attribution, domain=Dataset, range=Optional[Union[Union[dict, "Attribution"], list[Union[dict, "Attribution"]]]])
+                   model_uri=DCATAPPLUS.Dataset_qualified_attribution, domain=Dataset, range=Optional[Union[Union[dict, "Attribution"], list[Union[dict, "Attribution"]]]])
 
 slots.Dataset_qualified_relation = Slot(uri=DCAT.qualifiedRelation, name="Dataset_qualified_relation", curie=DCAT.curie('qualifiedRelation'),
-                   model_uri=DCATAP_PLUS.Dataset_qualified_relation, domain=Dataset, range=Optional[Union[Union[dict, "Relationship"], list[Union[dict, "Relationship"]]]])
+                   model_uri=DCATAPPLUS.Dataset_qualified_relation, domain=Dataset, range=Optional[Union[Union[dict, "Relationship"], list[Union[dict, "Relationship"]]]])
 
 slots.Dataset_related_resource = Slot(uri=DCTERMS.relation, name="Dataset_related_resource", curie=DCTERMS.curie('relation'),
-                   model_uri=DCATAP_PLUS.Dataset_related_resource, domain=Dataset, range=Optional[Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]]])
+                   model_uri=DCATAPPLUS.Dataset_related_resource, domain=Dataset, range=Optional[Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]]])
 
 slots.Dataset_release_date = Slot(uri=DCTERMS.issued, name="Dataset_release_date", curie=DCTERMS.curie('issued'),
-                   model_uri=DCATAP_PLUS.Dataset_release_date, domain=Dataset, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.Dataset_release_date, domain=Dataset, range=Optional[Union[str, XSDDate]])
 
 slots.Dataset_sample = Slot(uri=ADMS.sample, name="Dataset_sample", curie=ADMS.curie('sample'),
-                   model_uri=DCATAP_PLUS.Dataset_sample, domain=Dataset, range=Optional[Union[Union[dict, "Distribution"], list[Union[dict, "Distribution"]]]])
+                   model_uri=DCATAPPLUS.Dataset_sample, domain=Dataset, range=Optional[Union[Union[dict, "Distribution"], list[Union[dict, "Distribution"]]]])
 
 slots.Dataset_source = Slot(uri=DCTERMS.source, name="Dataset_source", curie=DCTERMS.curie('source'),
-                   model_uri=DCATAP_PLUS.Dataset_source, domain=Dataset, range=Optional[Union[dict[Union[str, DatasetId], Union[dict, "Dataset"]], list[Union[dict, "Dataset"]]]])
+                   model_uri=DCATAPPLUS.Dataset_source, domain=Dataset, range=Optional[Union[dict[Union[str, DatasetId], Union[dict, "Dataset"]], list[Union[dict, "Dataset"]]]])
 
 slots.Dataset_spatial_resolution = Slot(uri=DCAT.spatialResolutionInMeters, name="Dataset_spatial_resolution", curie=DCAT.curie('spatialResolutionInMeters'),
-                   model_uri=DCATAP_PLUS.Dataset_spatial_resolution, domain=Dataset, range=Optional[Decimal])
+                   model_uri=DCATAPPLUS.Dataset_spatial_resolution, domain=Dataset, range=Optional[Decimal])
 
 slots.Dataset_temporal_coverage = Slot(uri=DCTERMS.temporal, name="Dataset_temporal_coverage", curie=DCTERMS.curie('temporal'),
-                   model_uri=DCATAP_PLUS.Dataset_temporal_coverage, domain=Dataset, range=Optional[Union[Union[dict, "PeriodOfTime"], list[Union[dict, "PeriodOfTime"]]]])
+                   model_uri=DCATAPPLUS.Dataset_temporal_coverage, domain=Dataset, range=Optional[Union[Union[dict, "PeriodOfTime"], list[Union[dict, "PeriodOfTime"]]]])
 
 slots.Dataset_temporal_resolution = Slot(uri=DCAT.temporalResolution, name="Dataset_temporal_resolution", curie=DCAT.curie('temporalResolution'),
-                   model_uri=DCATAP_PLUS.Dataset_temporal_resolution, domain=Dataset, range=Optional[str])
+                   model_uri=DCATAPPLUS.Dataset_temporal_resolution, domain=Dataset, range=Optional[str])
 
 slots.Dataset_theme = Slot(uri=DCAT.theme, name="Dataset_theme", curie=DCAT.curie('theme'),
-                   model_uri=DCATAP_PLUS.Dataset_theme, domain=Dataset, range=Optional[Union[Union[dict, "Concept"], list[Union[dict, "Concept"]]]])
+                   model_uri=DCATAPPLUS.Dataset_theme, domain=Dataset, range=Optional[Union[Union[dict, "Concept"], list[Union[dict, "Concept"]]]])
 
 slots.Dataset_title = Slot(uri=DCTERMS.title, name="Dataset_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.Dataset_title, domain=Dataset, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.Dataset_title, domain=Dataset, range=Union[str, list[str]])
 
 slots.Dataset_type = Slot(uri=DCTERMS.type, name="Dataset_type", curie=DCTERMS.curie('type'),
-                   model_uri=DCATAP_PLUS.Dataset_type, domain=Dataset, range=Optional[Union[Union[dict, "Concept"], list[Union[dict, "Concept"]]]])
+                   model_uri=DCATAPPLUS.Dataset_type, domain=Dataset, range=Optional[Union[Union[dict, "Concept"], list[Union[dict, "Concept"]]]])
 
 slots.Dataset_version = Slot(uri=DCAT.version, name="Dataset_version", curie=DCAT.curie('version'),
-                   model_uri=DCATAP_PLUS.Dataset_version, domain=Dataset, range=Optional[str])
+                   model_uri=DCATAPPLUS.Dataset_version, domain=Dataset, range=Optional[str])
 
 slots.Dataset_version_notes = Slot(uri=ADMS.versionNotes, name="Dataset_version_notes", curie=ADMS.curie('versionNotes'),
-                   model_uri=DCATAP_PLUS.Dataset_version_notes, domain=Dataset, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.Dataset_version_notes, domain=Dataset, range=Optional[Union[str, list[str]]])
 
 slots.Dataset_was_generated_by = Slot(uri=PROV.wasGeneratedBy, name="Dataset_was_generated_by", curie=PROV.curie('wasGeneratedBy'),
-                   model_uri=DCATAP_PLUS.Dataset_was_generated_by, domain=Dataset, range=Union[dict[Union[str, DataGeneratingActivityId], Union[dict, DataGeneratingActivity]], list[Union[dict, DataGeneratingActivity]]])
+                   model_uri=DCATAPPLUS.Dataset_was_generated_by, domain=Dataset, range=Union[dict[Union[str, DataGeneratingActivityId], Union[dict, DataGeneratingActivity]], list[Union[dict, DataGeneratingActivity]]])
 
 slots.DatasetSeries_applicable_legislation = Slot(uri=DCATAP.applicableLegislation, name="DatasetSeries_applicable_legislation", curie=DCATAP.curie('applicableLegislation'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_applicable_legislation, domain=DatasetSeries, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
+                   model_uri=DCATAPPLUS.DatasetSeries_applicable_legislation, domain=DatasetSeries, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
 
 slots.DatasetSeries_contact_point = Slot(uri=DCAT.contactPoint, name="DatasetSeries_contact_point", curie=DCAT.curie('contactPoint'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_contact_point, domain=DatasetSeries, range=Optional[Union[Union[dict, "Kind"], list[Union[dict, "Kind"]]]])
+                   model_uri=DCATAPPLUS.DatasetSeries_contact_point, domain=DatasetSeries, range=Optional[Union[Union[dict, "Kind"], list[Union[dict, "Kind"]]]])
 
 slots.DatasetSeries_description = Slot(uri=DCTERMS.description, name="DatasetSeries_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_description, domain=DatasetSeries, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.DatasetSeries_description, domain=DatasetSeries, range=Union[str, list[str]])
 
 slots.DatasetSeries_frequency = Slot(uri=DCTERMS.accrualPeriodicity, name="DatasetSeries_frequency", curie=DCTERMS.curie('accrualPeriodicity'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_frequency, domain=DatasetSeries, range=Optional[Union[dict, "Frequency"]])
+                   model_uri=DCATAPPLUS.DatasetSeries_frequency, domain=DatasetSeries, range=Optional[Union[dict, "Frequency"]])
 
 slots.DatasetSeries_geographical_coverage = Slot(uri=DCTERMS.spatial, name="DatasetSeries_geographical_coverage", curie=DCTERMS.curie('spatial'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_geographical_coverage, domain=DatasetSeries, range=Optional[Union[Union[dict, "Location"], list[Union[dict, "Location"]]]])
+                   model_uri=DCATAPPLUS.DatasetSeries_geographical_coverage, domain=DatasetSeries, range=Optional[Union[Union[dict, "Location"], list[Union[dict, "Location"]]]])
 
 slots.DatasetSeries_modification_date = Slot(uri=DCTERMS.modified, name="DatasetSeries_modification_date", curie=DCTERMS.curie('modified'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_modification_date, domain=DatasetSeries, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.DatasetSeries_modification_date, domain=DatasetSeries, range=Optional[Union[str, XSDDate]])
 
 slots.DatasetSeries_publisher = Slot(uri=DCTERMS.publisher, name="DatasetSeries_publisher", curie=DCTERMS.curie('publisher'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_publisher, domain=DatasetSeries, range=Optional[Union[dict, Agent]])
+                   model_uri=DCATAPPLUS.DatasetSeries_publisher, domain=DatasetSeries, range=Optional[Union[dict, Agent]])
 
 slots.DatasetSeries_release_date = Slot(uri=DCTERMS.issued, name="DatasetSeries_release_date", curie=DCTERMS.curie('issued'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_release_date, domain=DatasetSeries, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.DatasetSeries_release_date, domain=DatasetSeries, range=Optional[Union[str, XSDDate]])
 
 slots.DatasetSeries_temporal_coverage = Slot(uri=DCTERMS.temporal, name="DatasetSeries_temporal_coverage", curie=DCTERMS.curie('temporal'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_temporal_coverage, domain=DatasetSeries, range=Optional[Union[Union[dict, "PeriodOfTime"], list[Union[dict, "PeriodOfTime"]]]])
+                   model_uri=DCATAPPLUS.DatasetSeries_temporal_coverage, domain=DatasetSeries, range=Optional[Union[Union[dict, "PeriodOfTime"], list[Union[dict, "PeriodOfTime"]]]])
 
 slots.DatasetSeries_title = Slot(uri=DCTERMS.title, name="DatasetSeries_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.DatasetSeries_title, domain=DatasetSeries, range=Union[str, list[str]])
+                   model_uri=DCATAPPLUS.DatasetSeries_title, domain=DatasetSeries, range=Union[str, list[str]])
 
 slots.DefinedTerm_title = Slot(uri=SCHEMA.name, name="DefinedTerm_title", curie=SCHEMA.curie('name'),
-                   model_uri=DCATAP_PLUS.DefinedTerm_title, domain=DefinedTerm, range=Optional[str])
+                   model_uri=DCATAPPLUS.DefinedTerm_title, domain=DefinedTerm, range=Optional[str])
 
 slots.Device_has_part = Slot(uri=DCTERMS.hasPart, name="Device_has_part", curie=DCTERMS.curie('hasPart'),
-                   model_uri=DCATAP_PLUS.Device_has_part, domain=Device, range=Optional[Union[dict[Union[str, DeviceId], Union[dict, "Device"]], list[Union[dict, "Device"]]]])
+                   model_uri=DCATAPPLUS.Device_has_part, domain=Device, range=Optional[Union[dict[Union[str, DeviceId], Union[dict, "Device"]], list[Union[dict, "Device"]]]])
 
 slots.Device_other_identifier = Slot(uri=ADMS.identifier, name="Device_other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.Device_other_identifier, domain=Device, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
+                   model_uri=DCATAPPLUS.Device_other_identifier, domain=Device, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
 
 slots.Distribution_access_URL = Slot(uri=DCAT.accessURL, name="Distribution_access_URL", curie=DCAT.curie('accessURL'),
-                   model_uri=DCATAP_PLUS.Distribution_access_URL, domain=Distribution, range=Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]])
+                   model_uri=DCATAPPLUS.Distribution_access_URL, domain=Distribution, range=Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]])
 
 slots.Distribution_access_service = Slot(uri=DCAT.accessService, name="Distribution_access_service", curie=DCAT.curie('accessService'),
-                   model_uri=DCATAP_PLUS.Distribution_access_service, domain=Distribution, range=Optional[Union[Union[dict, DataService], list[Union[dict, DataService]]]])
+                   model_uri=DCATAPPLUS.Distribution_access_service, domain=Distribution, range=Optional[Union[Union[dict, DataService], list[Union[dict, DataService]]]])
 
 slots.Distribution_applicable_legislation = Slot(uri=DCATAP.applicableLegislation, name="Distribution_applicable_legislation", curie=DCATAP.curie('applicableLegislation'),
-                   model_uri=DCATAP_PLUS.Distribution_applicable_legislation, domain=Distribution, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
+                   model_uri=DCATAPPLUS.Distribution_applicable_legislation, domain=Distribution, range=Optional[Union[dict[Union[str, LegalResourceId], Union[dict, "LegalResource"]], list[Union[dict, "LegalResource"]]]])
 
 slots.Distribution_availability = Slot(uri=DCATAP.availability, name="Distribution_availability", curie=DCATAP.curie('availability'),
-                   model_uri=DCATAP_PLUS.Distribution_availability, domain=Distribution, range=Optional[Union[dict, "Concept"]])
+                   model_uri=DCATAPPLUS.Distribution_availability, domain=Distribution, range=Optional[Union[dict, "Concept"]])
 
 slots.Distribution_byte_size = Slot(uri=DCAT.byteSize, name="Distribution_byte_size", curie=DCAT.curie('byteSize'),
-                   model_uri=DCATAP_PLUS.Distribution_byte_size, domain=Distribution, range=Optional[int])
+                   model_uri=DCATAPPLUS.Distribution_byte_size, domain=Distribution, range=Optional[int])
 
 slots.Distribution_checksum = Slot(uri=SPDX.checksum, name="Distribution_checksum", curie=SPDX.curie('checksum'),
-                   model_uri=DCATAP_PLUS.Distribution_checksum, domain=Distribution, range=Optional[Union[dict, Checksum]])
+                   model_uri=DCATAPPLUS.Distribution_checksum, domain=Distribution, range=Optional[Union[dict, Checksum]])
 
 slots.Distribution_compression_format = Slot(uri=DCAT.compressFormat, name="Distribution_compression_format", curie=DCAT.curie('compressFormat'),
-                   model_uri=DCATAP_PLUS.Distribution_compression_format, domain=Distribution, range=Optional[Union[dict, "MediaType"]])
+                   model_uri=DCATAPPLUS.Distribution_compression_format, domain=Distribution, range=Optional[Union[dict, "MediaType"]])
 
 slots.Distribution_description = Slot(uri=DCTERMS.description, name="Distribution_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.Distribution_description, domain=Distribution, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.Distribution_description, domain=Distribution, range=Optional[Union[str, list[str]]])
 
 slots.Distribution_documentation = Slot(uri=FOAF.page, name="Distribution_documentation", curie=FOAF.curie('page'),
-                   model_uri=DCATAP_PLUS.Distribution_documentation, domain=Distribution, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
+                   model_uri=DCATAPPLUS.Distribution_documentation, domain=Distribution, range=Optional[Union[dict[Union[str, DocumentId], Union[dict, "Document"]], list[Union[dict, "Document"]]]])
 
 slots.Distribution_download_URL = Slot(uri=DCAT.downloadURL, name="Distribution_download_URL", curie=DCAT.curie('downloadURL'),
-                   model_uri=DCATAP_PLUS.Distribution_download_URL, domain=Distribution, range=Optional[Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]]])
+                   model_uri=DCATAPPLUS.Distribution_download_URL, domain=Distribution, range=Optional[Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]]])
 
 slots.Distribution_format = Slot(uri=DCTERMS.format, name="Distribution_format", curie=DCTERMS.curie('format'),
-                   model_uri=DCATAP_PLUS.Distribution_format, domain=Distribution, range=Optional[Union[dict, "MediaTypeOrExtent"]])
+                   model_uri=DCATAPPLUS.Distribution_format, domain=Distribution, range=Optional[Union[dict, "MediaTypeOrExtent"]])
 
 slots.Distribution_has_policy = Slot(uri=ODRL.hasPolicy, name="Distribution_has_policy", curie=ODRL.curie('hasPolicy'),
-                   model_uri=DCATAP_PLUS.Distribution_has_policy, domain=Distribution, range=Optional[Union[dict, "Policy"]])
+                   model_uri=DCATAPPLUS.Distribution_has_policy, domain=Distribution, range=Optional[Union[dict, "Policy"]])
 
 slots.Distribution_language = Slot(uri=DCTERMS.language, name="Distribution_language", curie=DCTERMS.curie('language'),
-                   model_uri=DCATAP_PLUS.Distribution_language, domain=Distribution, range=Optional[Union[Union[dict, "LinguisticSystem"], list[Union[dict, "LinguisticSystem"]]]])
+                   model_uri=DCATAPPLUS.Distribution_language, domain=Distribution, range=Optional[Union[Union[dict, "LinguisticSystem"], list[Union[dict, "LinguisticSystem"]]]])
 
 slots.Distribution_licence = Slot(uri=DCTERMS.license, name="Distribution_licence", curie=DCTERMS.curie('license'),
-                   model_uri=DCATAP_PLUS.Distribution_licence, domain=Distribution, range=Optional[Union[dict, "LicenseDocument"]])
+                   model_uri=DCATAPPLUS.Distribution_licence, domain=Distribution, range=Optional[Union[dict, "LicenseDocument"]])
 
 slots.Distribution_linked_schemas = Slot(uri=DCTERMS.conformsTo, name="Distribution_linked_schemas", curie=DCTERMS.curie('conformsTo'),
-                   model_uri=DCATAP_PLUS.Distribution_linked_schemas, domain=Distribution, range=Optional[Union[Union[dict, "Standard"], list[Union[dict, "Standard"]]]])
+                   model_uri=DCATAPPLUS.Distribution_linked_schemas, domain=Distribution, range=Optional[Union[Union[dict, "Standard"], list[Union[dict, "Standard"]]]])
 
 slots.Distribution_media_type = Slot(uri=DCAT.mediaType, name="Distribution_media_type", curie=DCAT.curie('mediaType'),
-                   model_uri=DCATAP_PLUS.Distribution_media_type, domain=Distribution, range=Optional[Union[dict, "MediaType"]])
+                   model_uri=DCATAPPLUS.Distribution_media_type, domain=Distribution, range=Optional[Union[dict, "MediaType"]])
 
 slots.Distribution_modification_date = Slot(uri=DCTERMS.modified, name="Distribution_modification_date", curie=DCTERMS.curie('modified'),
-                   model_uri=DCATAP_PLUS.Distribution_modification_date, domain=Distribution, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.Distribution_modification_date, domain=Distribution, range=Optional[Union[str, XSDDate]])
 
 slots.Distribution_packaging_format = Slot(uri=DCAT.packageFormat, name="Distribution_packaging_format", curie=DCAT.curie('packageFormat'),
-                   model_uri=DCATAP_PLUS.Distribution_packaging_format, domain=Distribution, range=Optional[Union[dict, "MediaType"]])
+                   model_uri=DCATAPPLUS.Distribution_packaging_format, domain=Distribution, range=Optional[Union[dict, "MediaType"]])
 
 slots.Distribution_release_date = Slot(uri=DCTERMS.issued, name="Distribution_release_date", curie=DCTERMS.curie('issued'),
-                   model_uri=DCATAP_PLUS.Distribution_release_date, domain=Distribution, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.Distribution_release_date, domain=Distribution, range=Optional[Union[str, XSDDate]])
 
 slots.Distribution_rights = Slot(uri=DCTERMS.rights, name="Distribution_rights", curie=DCTERMS.curie('rights'),
-                   model_uri=DCATAP_PLUS.Distribution_rights, domain=Distribution, range=Optional[Union[dict, "RightsStatement"]])
+                   model_uri=DCATAPPLUS.Distribution_rights, domain=Distribution, range=Optional[Union[dict, "RightsStatement"]])
 
 slots.Distribution_spatial_resolution = Slot(uri=DCAT.spatialResolutionInMeters, name="Distribution_spatial_resolution", curie=DCAT.curie('spatialResolutionInMeters'),
-                   model_uri=DCATAP_PLUS.Distribution_spatial_resolution, domain=Distribution, range=Optional[Decimal])
+                   model_uri=DCATAPPLUS.Distribution_spatial_resolution, domain=Distribution, range=Optional[Decimal])
 
 slots.Distribution_status = Slot(uri=ADMS.status, name="Distribution_status", curie=ADMS.curie('status'),
-                   model_uri=DCATAP_PLUS.Distribution_status, domain=Distribution, range=Optional[Union[dict, "Concept"]])
+                   model_uri=DCATAPPLUS.Distribution_status, domain=Distribution, range=Optional[Union[dict, "Concept"]])
 
 slots.Distribution_temporal_resolution = Slot(uri=DCAT.temporalResolution, name="Distribution_temporal_resolution", curie=DCAT.curie('temporalResolution'),
-                   model_uri=DCATAP_PLUS.Distribution_temporal_resolution, domain=Distribution, range=Optional[str])
+                   model_uri=DCATAPPLUS.Distribution_temporal_resolution, domain=Distribution, range=Optional[str])
 
 slots.Distribution_title = Slot(uri=DCTERMS.title, name="Distribution_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.Distribution_title, domain=Distribution, range=Optional[Union[str, list[str]]])
+                   model_uri=DCATAPPLUS.Distribution_title, domain=Distribution, range=Optional[Union[str, list[str]]])
 
 slots.Entity_title = Slot(uri=DCTERMS.title, name="Entity_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.Entity_title, domain=Entity, range=Optional[str])
+                   model_uri=DCATAPPLUS.Entity_title, domain=Entity, range=Optional[str])
 
 slots.Entity_description = Slot(uri=DCTERMS.description, name="Entity_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.Entity_description, domain=Entity, range=Optional[str])
+                   model_uri=DCATAPPLUS.Entity_description, domain=Entity, range=Optional[str])
 
 slots.Entity_other_identifier = Slot(uri=ADMS.identifier, name="Entity_other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.Entity_other_identifier, domain=Entity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
+                   model_uri=DCATAPPLUS.Entity_other_identifier, domain=Entity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
 
 slots.Entity_has_part = Slot(uri=DCTERMS.hasPart, name="Entity_has_part", curie=DCTERMS.curie('hasPart'),
-                   model_uri=DCATAP_PLUS.Entity_has_part, domain=Entity, range=Optional[Union[dict[Union[str, EntityId], Union[dict, "Entity"]], list[Union[dict, "Entity"]]]])
+                   model_uri=DCATAPPLUS.Entity_has_part, domain=Entity, range=Optional[Union[dict[Union[str, EntityId], Union[dict, "Entity"]], list[Union[dict, "Entity"]]]])
 
 slots.Entity_part_of = Slot(uri=DCTERMS.isPartOf, name="Entity_part_of", curie=DCTERMS.curie('isPartOf'),
-                   model_uri=DCATAP_PLUS.Entity_part_of, domain=Entity, range=Optional[Union[dict[Union[str, EntityId], Union[dict, "Entity"]], list[Union[dict, "Entity"]]]])
+                   model_uri=DCATAPPLUS.Entity_part_of, domain=Entity, range=Optional[Union[dict[Union[str, EntityId], Union[dict, "Entity"]], list[Union[dict, "Entity"]]]])
 
 slots.EvaluatedActivity_other_identifier = Slot(uri=ADMS.identifier, name="EvaluatedActivity_other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.EvaluatedActivity_other_identifier, domain=EvaluatedActivity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
+                   model_uri=DCATAPPLUS.EvaluatedActivity_other_identifier, domain=EvaluatedActivity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
 
 slots.EvaluatedEntity_title = Slot(uri=DCTERMS.title, name="EvaluatedEntity_title", curie=DCTERMS.curie('title'),
-                   model_uri=DCATAP_PLUS.EvaluatedEntity_title, domain=EvaluatedEntity, range=Optional[str])
+                   model_uri=DCATAPPLUS.EvaluatedEntity_title, domain=EvaluatedEntity, range=Optional[str])
 
 slots.EvaluatedEntity_description = Slot(uri=DCTERMS.description, name="EvaluatedEntity_description", curie=DCTERMS.curie('description'),
-                   model_uri=DCATAP_PLUS.EvaluatedEntity_description, domain=EvaluatedEntity, range=Optional[str])
+                   model_uri=DCATAPPLUS.EvaluatedEntity_description, domain=EvaluatedEntity, range=Optional[str])
 
 slots.EvaluatedEntity_was_generated_by = Slot(uri=PROV.wasGeneratedBy, name="EvaluatedEntity_was_generated_by", curie=PROV.curie('wasGeneratedBy'),
-                   model_uri=DCATAP_PLUS.EvaluatedEntity_was_generated_by, domain=EvaluatedEntity, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, Activity]], list[Union[dict, Activity]]]])
+                   model_uri=DCATAPPLUS.EvaluatedEntity_was_generated_by, domain=EvaluatedEntity, range=Optional[Union[dict[Union[str, ActivityId], Union[dict, Activity]], list[Union[dict, Activity]]]])
 
 slots.EvaluatedEntity_other_identifier = Slot(uri=ADMS.identifier, name="EvaluatedEntity_other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.EvaluatedEntity_other_identifier, domain=EvaluatedEntity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
+                   model_uri=DCATAPPLUS.EvaluatedEntity_other_identifier, domain=EvaluatedEntity, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
 
 slots.Identifier_notation = Slot(uri=SKOS.notation, name="Identifier_notation", curie=SKOS.curie('notation'),
-                   model_uri=DCATAP_PLUS.Identifier_notation, domain=Identifier, range=str)
+                   model_uri=DCATAPPLUS.Identifier_notation, domain=Identifier, range=str)
 
 slots.LicenseDocument_type = Slot(uri=DCTERMS.type, name="LicenseDocument_type", curie=DCTERMS.curie('type'),
-                   model_uri=DCATAP_PLUS.LicenseDocument_type, domain=LicenseDocument, range=Optional[Union[Union[dict, Concept], list[Union[dict, Concept]]]])
+                   model_uri=DCATAPPLUS.LicenseDocument_type, domain=LicenseDocument, range=Optional[Union[Union[dict, Concept], list[Union[dict, Concept]]]])
 
 slots.Location_bbox = Slot(uri=DCAT.bbox, name="Location_bbox", curie=DCAT.curie('bbox'),
-                   model_uri=DCATAP_PLUS.Location_bbox, domain=Location, range=Optional[str])
+                   model_uri=DCATAPPLUS.Location_bbox, domain=Location, range=Optional[str])
 
 slots.Location_centroid = Slot(uri=DCAT.centroid, name="Location_centroid", curie=DCAT.curie('centroid'),
-                   model_uri=DCATAP_PLUS.Location_centroid, domain=Location, range=Optional[str])
+                   model_uri=DCATAPPLUS.Location_centroid, domain=Location, range=Optional[str])
 
 slots.Location_geometry = Slot(uri=LOCN.geometry, name="Location_geometry", curie=LOCN.curie('geometry'),
-                   model_uri=DCATAP_PLUS.Location_geometry, domain=Location, range=Optional[Union[dict, "Geometry"]])
+                   model_uri=DCATAPPLUS.Location_geometry, domain=Location, range=Optional[Union[dict, "Geometry"]])
 
 slots.PeriodOfTime_beginning = Slot(uri=TIME.hasBeginning, name="PeriodOfTime_beginning", curie=TIME.curie('hasBeginning'),
-                   model_uri=DCATAP_PLUS.PeriodOfTime_beginning, domain=PeriodOfTime, range=Optional[Union[dict, "TimeInstant"]])
+                   model_uri=DCATAPPLUS.PeriodOfTime_beginning, domain=PeriodOfTime, range=Optional[Union[dict, "TimeInstant"]])
 
 slots.PeriodOfTime_end = Slot(uri=TIME.hasEnd, name="PeriodOfTime_end", curie=TIME.curie('hasEnd'),
-                   model_uri=DCATAP_PLUS.PeriodOfTime_end, domain=PeriodOfTime, range=Optional[Union[dict, "TimeInstant"]])
+                   model_uri=DCATAPPLUS.PeriodOfTime_end, domain=PeriodOfTime, range=Optional[Union[dict, "TimeInstant"]])
 
 slots.PeriodOfTime_end_date = Slot(uri=DCAT.endDate, name="PeriodOfTime_end_date", curie=DCAT.curie('endDate'),
-                   model_uri=DCATAP_PLUS.PeriodOfTime_end_date, domain=PeriodOfTime, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.PeriodOfTime_end_date, domain=PeriodOfTime, range=Optional[Union[str, XSDDate]])
 
 slots.PeriodOfTime_start_date = Slot(uri=DCAT.startDate, name="PeriodOfTime_start_date", curie=DCAT.curie('startDate'),
-                   model_uri=DCATAP_PLUS.PeriodOfTime_start_date, domain=PeriodOfTime, range=Optional[Union[str, XSDDate]])
+                   model_uri=DCATAPPLUS.PeriodOfTime_start_date, domain=PeriodOfTime, range=Optional[Union[str, XSDDate]])
 
 slots.QualitativeAttribute_value = Slot(uri=PROV.value, name="QualitativeAttribute_value", curie=PROV.curie('value'),
-                   model_uri=DCATAP_PLUS.QualitativeAttribute_value, domain=QualitativeAttribute, range=str)
+                   model_uri=DCATAPPLUS.QualitativeAttribute_value, domain=QualitativeAttribute, range=str)
 
 slots.QuantitativeAttribute_value = Slot(uri=PROV.value, name="QuantitativeAttribute_value", curie=PROV.curie('value'),
-                   model_uri=DCATAP_PLUS.QuantitativeAttribute_value, domain=QuantitativeAttribute, range=float)
+                   model_uri=DCATAPPLUS.QuantitativeAttribute_value, domain=QuantitativeAttribute, range=float)
 
 slots.Relationship_had_role = Slot(uri=DCAT.hadRole, name="Relationship_had_role", curie=DCAT.curie('hadRole'),
-                   model_uri=DCATAP_PLUS.Relationship_had_role, domain=Relationship, range=Union[Union[dict, "Role"], list[Union[dict, "Role"]]])
+                   model_uri=DCATAPPLUS.Relationship_had_role, domain=Relationship, range=Union[Union[dict, "Role"], list[Union[dict, "Role"]]])
 
 slots.Relationship_relation = Slot(uri=DCTERMS.relation, name="Relationship_relation", curie=DCTERMS.curie('relation'),
-                   model_uri=DCATAP_PLUS.Relationship_relation, domain=Relationship, range=Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]])
+                   model_uri=DCATAPPLUS.Relationship_relation, domain=Relationship, range=Union[dict[Union[str, ResourceId], Union[dict, "Resource"]], list[Union[dict, "Resource"]]])
 
 slots.Software_has_part = Slot(uri=DCTERMS.hasPart, name="Software_has_part", curie=DCTERMS.curie('hasPart'),
-                   model_uri=DCATAP_PLUS.Software_has_part, domain=Software, range=Optional[Union[dict[Union[str, SoftwareId], Union[dict, "Software"]], list[Union[dict, "Software"]]]])
+                   model_uri=DCATAPPLUS.Software_has_part, domain=Software, range=Optional[Union[dict[Union[str, SoftwareId], Union[dict, "Software"]], list[Union[dict, "Software"]]]])
 
 slots.Software_other_identifier = Slot(uri=ADMS.identifier, name="Software_other_identifier", curie=ADMS.curie('identifier'),
-                   model_uri=DCATAP_PLUS.Software_other_identifier, domain=Software, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])
+                   model_uri=DCATAPPLUS.Software_other_identifier, domain=Software, range=Optional[Union[Union[dict, "Identifier"], list[Union[dict, "Identifier"]]]])

--- a/src/dcat_ap_plus/datamodel/dcat_ap_plus_pydantic.py
+++ b/src/dcat_ap_plus/datamodel/dcat_ap_plus_pydantic.py
@@ -27,7 +27,7 @@ from pydantic import (
 
 
 metamodel_version = "None"
-version = "0.1.0rc1.post21.dev0+3faed58"
+version = "0.1.0rc3.post21.dev0+913fb36"
 
 
 class ConfiguredBaseModel(BaseModel):
@@ -61,7 +61,7 @@ class LinkMLMeta(RootModel):
         return key in self.root
 
 
-linkml_meta = LinkMLMeta({'default_prefix': 'dcatap_plus',
+linkml_meta = LinkMLMeta({'default_prefix': 'dcatapplus',
      'default_range': 'string',
      'description': 'This metadata schema is an Extension of the DCAT Application '
                     'Profile for Providing Links to Use-case Specific Context. It '
@@ -99,8 +99,8 @@ linkml_meta = LinkMLMeta({'default_prefix': 'dcatap_plus',
                            'prefix_reference': 'http://www.w3.org/ns/dcat#'},
                   'dcatap': {'prefix_prefix': 'dcatap',
                              'prefix_reference': 'http://data.europa.eu/r5r/'},
-                  'dcatap_plus': {'prefix_prefix': 'dcatap_plus',
-                                  'prefix_reference': 'https://w3id.org/nfdi-de/dcat-ap-plus/'},
+                  'dcatapplus': {'prefix_prefix': 'dcatapplus',
+                                 'prefix_reference': 'https://w3id.org/nfdi-de/dcat-ap-plus/'},
                   'dcterms': {'prefix_prefix': 'dcterms',
                               'prefix_reference': 'http://purl.org/dc/terms/'},
                   'eli': {'prefix_prefix': 'eli',

--- a/src/dcat_ap_plus/schema/dcat_ap_plus.yaml
+++ b/src/dcat_ap_plus/schema/dcat_ap_plus.yaml
@@ -1,6 +1,6 @@
 ---
 id: https://w3id.org/nfdi-de/dcat-ap-plus/
-version: "0.1.0rc1.post21.dev0+3faed58"  # Managed by dynamic-versioning. Don't change this line!
+version: "0.1.0rc3.post21.dev0+913fb36"  # Managed by dynamic-versioning. Don't change this line!
 name: dcat-ap-plus
 description: >-
   This metadata schema is an Extension of the DCAT Application Profile
@@ -53,7 +53,7 @@ prefixes:
   iana: https://www.iana.org/assignments/
   epos: https://www.epos-eu.org/epos-dcat-ap#
   schema: http://schema.org/
-  dcatap_plus: https://w3id.org/nfdi-de/dcat-ap-plus/
+  dcatapplus: https://w3id.org/nfdi-de/dcat-ap-plus/
   BFO: http://purl.obolibrary.org/obo/BFO_
   OBI: http://purl.obolibrary.org/obo/OBI_
   IAO: http://purl.obolibrary.org/obo/IAO_
@@ -63,7 +63,7 @@ prefixes:
   AFE: http://purl.allotrope.org/ontologies/equipment#AFE_
   qudt: http://qudt.org/schema/qudt/
   ex: http://example.org/
-default_prefix: dcatap_plus
+default_prefix: dcatapplus
 default_range: string
 subsets:
   domain_agnostic_core:


### PR DESCRIPTION
As discussed with Philip, we harmonize the namespace declaration of dcatap_plus to dcatapplus in the main schema file, to harmonize with the naming convention in ChemDCAT-AP.