### PR TITLE
Fix markdown rendering in docu pages for linkml >=1.11

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,20 +94,30 @@ extra:
       - stable
 
 markdown_extensions:
-  - admonition
-  - footnotes
-  - pymdownx.details
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.superfences:
-      # make exceptions to highlighting of code:
+      # https://mkdocs-mermaid2.readthedocs.io/en/latest/superfences
+      # custom code highlighting rules
       custom_fences:
         - name: mermaid
+          # disable code highlighting to display diagrams
+          format: !!python/name:pymdownx.superfences.fence_code_format
           class: mermaid
-          format: !!python/name:mermaid2.fence_mermaid_custom
-  - pymdownx.tasklist:
-      custom_checkbox: true
+  # https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/
+  # auto-link HTML, FTP, and email links
+  - pymdownx.magiclink
+  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#admonition
+  # support for call-outs
+  - admonition
+  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#tables
+  # create tables
+  - tables
+  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists
+  # enables use of HTML attributes and CSS classes to applicable elements
+  - attr_list
+  # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#markdown-in-html
+  # write markdown inside of HTML
+  - md_in_html
+
 exclude_docs: |
   /templates-linkml/
 


### PR DESCRIPTION
To fix the problem I copied the `markdown_extension` section verbatim from current main of linkml-project-copier.

The problem was that the breaking changes were not documented in the release notes of linkml 1.11.0 or 1.11.1.

Closes #93
